### PR TITLE
Add dashboards for 3.8 and new V2 API

### DIFF
--- a/ArangoDB_3.8/ArangoDB_3.8_all_metrics-1619088855843.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_all_metrics-1619088855843.json
@@ -1,0 +1,8189 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 4,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_heartbeat_send_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time required to send a heartbeat",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_sum[60s]) / rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 7,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 8,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of AQL queries finished",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of AQL queries executing",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory limit for all AQL queries combined",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 11,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 17,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 18,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of transactions using sequential locking of collections to avoid deadlocking.\nBy default, a coordinator will try to lock all shards of a collection in parallel.\nThis approach is normally fast but can cause deadlocks with other transactions that\nlock the same shards in a different order. In case such a deadlock is detected, the\ncoordinator will abort the lock round and start a new one that locks all shards in\nsequential order. This will avoid deadlocks, but has a higher setup overhead.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 23,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_sequential_mode_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions using sequential locking of collections to avoid deadlocking",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 21,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total amount of time it took to acquire collection/shard locks for\nwrite operations, summed up for all collections/shards. Will not be increased \nfor any read operations.\nThe value is measured in microseconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 22,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_micros_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total amount of collection lock acquisition time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection write locks.\nThis counter will be increased whenever a collection write lock\ncannot be acquired within the configured lock timeout. \nThis can only happen if writes on a collection are locked out by\nother operations on the collection that use an exclusive lock. Writes\nare not locked out by other, non-exclusively locked writes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 25,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_write_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection write locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection exclusive locks.\nThis counter will be increased whenever an exclusive collection lock\ncannot be acquired within the configured lock timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_exclusive_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection exclusive locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 27,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 26,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 29,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 30,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 33,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 32,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 35,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 36,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 39,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 38,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 41,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 42,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations (insert, update, replace, remove) on\nleaders, excluding writes by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 45,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 47,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 99
+          },
+          "id": 46,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 99
+          },
+          "id": 49,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 107
+          },
+          "id": 48,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 50,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 51,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 53,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 54,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 55,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 56,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 57,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the connection's total lifetime, i.e., the time between the\npoint when the connection was established until it was closed. Smaller\nnumbers indicate that there is not a lot of load and/or that connections\nare not reused for multiple requests. Consider using keep-alive header\nor HTTP/2 or VST.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 58,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_connection_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total connection time of a client",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the connection's total lifetime, i.e., the time between the\npoint when the connection was established until it was closed. Smaller\nnumbers indicate that there is not a lot of load and/or that connections\nare not reused for multiple requests. Consider using keep-alive header\nor HTTP/2 or VST.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 59,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_connection_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total connection time of a client (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the connection's total lifetime, i.e., the time between the\npoint when the connection was established until it was closed. Smaller\nnumbers indicate that there is not a lot of load and/or that connections\nare not reused for multiple requests. Consider using keep-alive header\nor HTTP/2 or VST.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 60,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_connection_time_sum[60s]) / rate(arangodb_client_connection_statistics_connection_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total connection time of a client (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 61,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 62,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 63,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 64,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 66,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 67,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 70,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of intermediate commits performed in transactions.\nAn intermediate commit happens if a logical transaction needs to be\nsplit into multiple physical transaction because of the volume of data\nhandled in the transaction. The thresholds for when to perform an\nintermediate commit can be controlled by startup options \n`--rocksdb.intermediate-commit-count` (number of write operations after\nwhich an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n(cumulated size of write operations after which an intermediate commit is triggered).\nThe values can also be overridden for individual transactions.\nThis metric was named `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_intermediate_commits_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of intermediate commits performed in transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 99,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 100,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 212
+          },
+          "id": 103,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 212
+          },
+          "id": 104,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 220
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 220
+          },
+          "id": 106,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 107,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations by synchronous\nreplication on followers. Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 108,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations by synchronous replication.\nThis metric is only present if the option\n`--server.export-read-write-metrics` is set to `true`.\nTotal number of document write operations (insert, update, replace, remove)\nexecuted by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 109,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of refusal answers from a follower during synchronous replication.\nA refusal answer will only be sent by a follower if the follower is under\nthe impression that the replication request was not sent by the current\nshard leader. This can happen if replication requests to the follower are \ndelayed or the follower is slow to process incoming requests and there was \na leader change for the shard.\nIf such a refusal answer is received by the shard leader, it will drop the\nfollower from the list of followers.\nThis metrics was named `arangodb_refused_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 110,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_refused_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of refusal answers from a follower during synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "When using a DC-2-DC configuration of ArangoDB this metric is active on both data-centers.\nIt indicates that the follower data-center peridocally matches the available databases and collections\nin order to mirror them. If no DC-2-DC is set up this value is expected to be 0.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 111,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_cluster_inventory_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "(DC-2-DC only) Number of times the database and collection overviews have been requested",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Measures the time required to clone the existing leader copy of the data onto a new replica shard.\nWill only be measured on the follower server. This time is expected to increase whenever new followers\nare created, e.g. increasing replication factor, shard redistribution.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 112,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of requests required to transport data to this server,\nas a replica for a shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 113,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of bytes replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 114,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The accumulated time the follower waited for the leader to send\nthe data is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 115,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication requests in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of data transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 116,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests used in initial asynchronous replication phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. Whenever there is a communication issue between the follower and\nthe leader of the shard it will be counted here for the follower. This communication\nissues cover failed connections or http errors, but they also cover invalid or\nunexpected data formats revieved on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 117,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_failed_connects_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of failed connection attempts and response errors during initial asynchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for replication key\nchunks determination requests, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the initial step of getting\nthe checksums for the key chunks.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_chunks_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication key chunks determination requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for requesting actual\ndocuments for the initial replication, in milliseconds. This is part\nof the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the final step of actually\ngetting the needed documents.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 119,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_docs_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to request replication docs data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Accumulated time needed to apply replication initial sync insertions.\nThis counter exhibits the accumulated wait time for actually inserting\ndocuments for the initial synchronization, in milliseconds. This is\npart of the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the actual insertion of\nreplicated documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 120,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_insert_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync insertions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for fetching key\nlists for a chunk, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the second step of getting\nlists of key/revision pairs for each chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 121,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_keys_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for removing local\ndocuments during initial synchronization of a shard on the follower,\nin milliseconds. This is part of the older (pre 3.8) initial\nreplication protocol, which might still be used in 3.8 for collections\nwhich have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the intermediate step of\nremoving unneeded documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "id": 122,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_remove_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync removals",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of bytes received\nfor initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates number of bytes received for all three steps.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 61
+          },
+          "id": 123,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated amount of bytes received in initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents inserted on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents inserted in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 69
+          },
+          "id": 124,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_inserted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents inserted by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents removed on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents removed in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 69
+          },
+          "id": 125,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_removed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents removed by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents fetched on the\nfollower from the leader during initial synchronization of shards.\nThis is part of the older (pre 3.8) initial replication protocol,\nwhich might still be used in 3.8 for collections which have been\ncreated by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents fetched from the\nleader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 77
+          },
+          "id": 126,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requested_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents requested by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of times documents have been\nfetched on the follower from the leader during initial synchronization\nof shards. This is part of the older (pre 3.8) initial replication\nprotocol, which might still be used in 3.8 for collections which have\nbeen created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of times documents have been\nfetched from the leader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 77
+          },
+          "id": 127,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync docs requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of keys requests for\ninitial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric counts the number of times the follower fetches a list of\nkeys for some chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 85
+          },
+          "id": 128,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_keys_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of all synchronous replication operation requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 85
+          },
+          "id": 129,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_number_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total time needed for all synchronous replication requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 93
+          },
+          "id": 130,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed for all synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated time needed to locally process the continuous\nreplication log on a follower received from a replication\nleader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 93
+          },
+          "id": 131,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication tailing data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of bytes received from a leader for replication tailing requests. The higher the amount of bytes is, the more data is being processed afterwards on the follower dbserver.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 101
+          },
+          "id": 132,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of bytes received for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of replication tailing document inserts/replaces processed on a follower.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 101
+          },
+          "id": 133,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of replication tailing document inserts/replaces processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing failures due to missing tick on leader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 109
+          },
+          "id": 134,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_follow_tick_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing failures due to missing tick on leader",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing markers processed on a follower\ndbserver. Markers are specific operations which are part of the\nwrite-ahead log (WAL). Example actions which are being used in\nmarkers: Create or drop a database. Create, drop, rename, change\nor truncate a collection. Create or drop an index. Create, drop,\nchange a view. Start, commit or abort a transaction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 109
+          },
+          "id": 135,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_markers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing markers processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The amount of document removal based marker operations on a\nfollower dbserver.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 117
+          },
+          "id": 136,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_removals_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing document removals processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Aggregated wait time for replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 117
+          },
+          "id": 137,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregated wait time for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of network replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 125
+          },
+          "id": 138,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 125
+          },
+          "id": 139,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 133
+          },
+          "id": 140,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 133
+          },
+          "id": 141,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 141
+          },
+          "id": 142,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of times a mismatching shard checksum was detected when\nsyncing shards. This is a very special metric which is rarely used.\nWhen followers of shards get in sync with their leaders, just when\neverything is completed a final checksum is taken as an additional\nprecaution. If this checksum differs between leader an follower, the\nresync process starts from scratch.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 141
+          },
+          "id": 143,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_sync_wrong_checksum_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a mismatching shard checksum was detected when syncing shards",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 144,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the collection/shard lock acquisition times. Locks will be acquired for\nall write operations, but not for read operations.\nThe values here are measured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 6
+          },
+          "id": 145,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_lock_acquisition_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Collection lock acquisition time histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the collection/shard lock acquisition times. Locks will be acquired for\nall write operations, but not for read operations.\nThe values here are measured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "id": 146,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Collection lock acquisition time histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the collection/shard lock acquisition times. Locks will be acquired for\nall write operations, but not for read operations.\nThe values here are measured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 147,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_time_sum[60s]) / rate(arangodb_collection_lock_acquisition_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Collection lock acquisition time histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stalled (slowed) write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 148,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stalls_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stalled (slowed) write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stopped write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high,\nbut write stops are considerably worse, since they can lead to service\nunavailability.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 149,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stops_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stopped write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-actual-delayed-write-rate\".\nIt shows the current actual delayed write rate. The value 0 means no delay.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 150,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_actual_delayed_write_rate",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-actual-delayed-write-rate\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"background-errors\". It shows\nthe accumulated number of background errors.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "id": 151,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_background_errors",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"background-errors\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-base-level\".\nIt shows the number of the level to which L0 data will be\ncompacted.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "id": 152,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_base_level",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-base-level\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-block-cache-capacity\".\nIt shows the block cache capacity in bytes. This can be configured with\nthe `--rocksdb.block-cache-size` option, for details, see\n[the manual](https://www.arangodb.com/docs/stable/programs-arangod-options.html#rocksdb).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 38
+          },
+          "id": 153,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_block_cache_capacity",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-block-cache-capacity\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-block-cache-pinned-usage\".\nIt shows the memory size for the RocksDB block cache for the entries \nwhich are pinned, in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 38
+          },
+          "id": 154,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_block_cache_pinned_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-block-cache-pinned-usage\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-block-cache-usage\".\nIt shows the memory size for the entries residing in the block cache,\nin bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 155,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_block_cache_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-block-cache-usage\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reflects the current global allocation for the ArangoDB\ncache which sits in front of RocksDB. For example, the edge cache\ncounts towards this allocation. All these caches together have a \nglobal limit which can be controlled with the `--cache.size` option.\nSee [the manual for details](https://www.arangodb.com/docs/stable/programs-arangod-options.html#cache).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 156,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_cache_allocated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Global current allocation of ArangoDB cache",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reflects the lifetime hit rate of the ArangoDB in-memory\ncache which is sitting in front of RocksDB. For example, the edge\ncache is a part of this. The value will be a ratio between 0 and 1.\n\"Lifetime\" means here that accounting is done from the most recent\nstart of the `arangod` instance.\nIf the hit rate is too low, you might have to little RAM available\nfor the in-memory caches.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 54
+          },
+          "id": 157,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_cache_hit_rate_lifetime",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lifetime hit rate of the ArangoDB cache in front of RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reflects the recent hit rate of the ArangoDB in-memory\ncache which is sitting in front of RocksDB. For example, the edge\ncache is a part of this. The value will be a ratio between 0 and 1.\nIf the hit rate is too low, you might have to little RAM available\nfor the in-memory caches.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 54
+          },
+          "id": 158,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_cache_hit_rate_recent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Recent hit rate of the ArangoDB cache in front of RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reflects the current global allocation limit for the\nArangoDB caches which sit in front of RocksDB. For example, the\nedge cache counts towards this allocation. This global limit can\nbe controlled with the `--cache.size` option. See\n[the manual for details](https://www.arangodb.com/docs/stable/programs-arangod-options.html#cache).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "id": 159,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_cache_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Global allocation limit for the ArangoDB cache in front of RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"compaction-pending\".\nIt shows the number of column families for which at least one compaction\nis pending.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 62
+          },
+          "id": 160,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compaction_pending",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"compaction-pending\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 0 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 0.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 70
+          },
+          "id": 161,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level0",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level0\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 1 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 1.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "id": 162,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level1",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level1\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 2 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 2.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 78
+          },
+          "id": 163,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level2",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level2\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 3 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 3.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 78
+          },
+          "id": 164,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level3",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level3\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 4 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 4.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 86
+          },
+          "id": 165,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level4",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level4\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 5 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 5.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 86
+          },
+          "id": 166,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level5",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level5\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the compression ratio of data at level 6 in RocksDB's\nlog structured merge tree. Here, compression\nratio is defined as uncompressed data size / compressed file size.\nReturns \"-1.0\" if there are no open files at level 6.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 94
+          },
+          "id": 167,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_compression_ratio_at_level6",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-compression-ratio-at-level6\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-cur-size-active-mem-table\".\nIt shows the approximate size of the active memtable in bytes, summed\nover all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 94
+          },
+          "id": 168,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_cur_size_active_mem_table",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-cur-size-active-mem-table\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-cur-size-all-mem-tables\".\nIt shows the approximate size of active and unflushed immutable memtables\nin bytes, summed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 102
+          },
+          "id": 169,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_cur_size_all_mem_tables",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-cur-size-all-mem-tables\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exposes the current write rate limit of the ArangoDB\nRocksDB throttle. The throttle limits the write rate to allow\nRocksDB's background threads to catch up with compactions and not\nfall behind too much, since this would in the end lead to nasty\nwrite stops in RocksDB and incur considerable delays. If 0 is\nshown, no throttling happens, otherwise, you see the current\nwrite rate limit in bytes per second. See \n[the manual](https://www.arangodb.com/docs/stable/programs-arangod-options.html#rocksdb) for details.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 102
+          },
+          "id": 170,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_engine_throttle_bps",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current rate of the RocksDB throttle in bytes per second",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-estimate-live-data-size\".\nIt shows an estimate of the amount of live data in bytes, summed over\nall column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 110
+          },
+          "id": 171,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_estimate_live_data_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-estimate-live-data-size\" - sum over all column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-estimate-num-keys\".\nIt shows the estimated number of total keys in the active and unflushed\nimmutable memtables and storage, summed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 110
+          },
+          "id": 172,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_estimate_num_keys",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-estimate-num-keys\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric\n\"rocksdb-estimate-pending-compaction-bytes\".\nIt shows the estimated total number of bytes compaction needs to\nrewrite to get all levels down to under target size. Not valid for\nother compactions than level-based. This value is summed over all\ncolumn families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 118
+          },
+          "id": 173,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_estimate_pending_compaction_bytes",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-estimate-pending-compaction-bytes\" - sum over all column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric\n\"rocksdb-estimate-table-readers-mem\".\nIt shows the estimated memory used for reading SST tables, excluding\nmemory used in block cache (e.g. filter and index blocks), summed over\nall column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 118
+          },
+          "id": 174,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_estimate_table_readers_mem",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-estimate-table-readers-mem\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric shows the currently free disk space in bytes on the volume\nwhich is used by RocksDB. Since RocksDB does not like out of disk\nspace scenarios, please make sure that there is enough free disk space\navailable at all times!  Note that this metric is only available/populated on some platforms.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 126
+          },
+          "id": 175,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_free_disk_space",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Free disk space in bytes on volume used by RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric shows the currently free number of inodes on the disk volume\nused by RocksDB. Since RocksDB does not like out of disk space\nscenarios, please make sure that there is enough free inodes available\nat all times! Note that this metric is only available/populated on some platforms.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 126
+          },
+          "id": 176,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_free_inodes",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of free inodes on the volume used by RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-is-file-deletions-enabled\".\nIt shows 0 if deletion of obsolete files is enabled, and otherwise,\nit shows a non-zero number. Note that for ArangoDB, this is supposed\nto always return 1, since the deletion of obsolete WAL files is done\nfrom ArangoDB, externally to RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 134
+          },
+          "id": 177,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_is_file_deletions_enabled",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-is-file-deletions-enabled\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-is-write-stopped\".\nIt shows 1 if writing to RocksDB has been stopped, and otherwise 0.\nIf 1 is shown, this usually means that there are too many uncompacted\nfiles and the RocksDB background threads have not managed to keep up\nwith their compaction work. This situation should be avoided, since\nnasty delays in database operations are incurred. If in doubt,\ncontact ArangoDB support.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 134
+          },
+          "id": 178,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_is_write_stopped",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-is-write-stopped\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-live-sst-files-size\".\nIt shows the total size in bytes of all SST files belonging to the latest\nLSM tree, summed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 142
+          },
+          "id": 179,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_live_sst_files_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-live-sst-files-size\" - sum over all column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"mem-table-flush-pending\". It\nshows the number of column families for which a memtable flush is\npending.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 142
+          },
+          "id": 180,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_mem_table_flush_pending",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"mem_table_flush_pending\", sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-min-log-number-to-keep\".\nIt shows the minimum log number of the log files that should be kept.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 150
+          },
+          "id": 181,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_min_log_number_to_keep",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-min-log-number-to-keep\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric\n\"rocksdb-num-deletes-active-mem-table\".\nIt shows the total number of delete entries in the active memtable,\nsummed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 150
+          },
+          "id": 182,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_deletes_active_mem_table",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-deletes-active-mem-table\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric\n\"rocksdb-num-deletes-imm-mem-tables\".\nIt shows the total number of delete entries in the unflushed immutable\nmemtables, summed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 158
+          },
+          "id": 183,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_deletes_imm_mem_tables",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-deletes-imm-mem-tables\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \n\"rocksdb-num-entries-active-mem-table\".\nIt shows the total number of entries in the active memtable,\nsummed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 158
+          },
+          "id": 184,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_entries_active_mem_table",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-entries-active-mem-table\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric\n\"rocksdb-num-entries-imm-mem-tables\".\nIt shows the total number of entries in the unflushed immutable memtables,\nsummed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 166
+          },
+          "id": 185,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_entries_imm_mem_tables",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-entries-imm-mem-tables\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 0 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 166
+          },
+          "id": 186,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level0",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level0\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 1 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 174
+          },
+          "id": 187,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level1",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level1\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 2 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 174
+          },
+          "id": 188,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level2",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level2\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 3 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 182
+          },
+          "id": 189,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level3",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level3\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 4 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 182
+          },
+          "id": 190,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level4",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level4\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 5 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 190
+          },
+          "id": 191,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level5",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level5\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reports the number of files at level 6 in the log structured\nmerge tree of RocksDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 190
+          },
+          "id": 192,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_files_at_level6",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-files-at-level6\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"num-immutable-mem-table\", \nwhich shows the number of immutable memtables that have not yet been\nflushed. This value is the sum over all column families.\n\nMemtables are sorted tables of key/value pairs which begin\nto be built up in memory. At some stage they are closed and become\nimmutable, and some time later they are flushed to disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 198
+          },
+          "id": 193,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_immutable_mem_table",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-immutable-mem-table\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"num-immutable-mem-table-flushed\", \nwhich shows the number of immutable memtables that have already been\nflushed. This value is the sum over all column families.\n\nMemtables are sorted tables of key/value pairs which begin\nto be built up in memory. At some stage they are closed and become\nimmutable, and some time later they are flushed to disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 198
+          },
+          "id": 194,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_immutable_mem_table_flushed",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"num-immutable-mem-table-flushed\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-num-live-versions\".\nIt shows the number of live versions. `Version` is an internal data\nstructure. See `version_set.h` in the RocksDB source for details. More\nlive versions often mean more SST files are held from being deleted,\nby iterators or unfinished compactions. This number is the number\nsummed up over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 206
+          },
+          "id": 195,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_live_versions",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-live-versions\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-num-running-compactions\".\nIt shows the number of currently running compactions.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 206
+          },
+          "id": 196,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_running_compactions",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-running-compactions\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-num-running-flushes\".\nIt shows the number of currently running flushes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 214
+          },
+          "id": 197,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_running_flushes",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-running-flushes\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-num-snapshots\".\nIt shows the number of unreleased snapshots of the database.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 214
+          },
+          "id": 198,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_num_snapshots",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-num-snapshots\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-oldest-snapshot-time\".\nIt shows a number representing the unix timestamp of the oldest\nunreleased snapshot.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 222
+          },
+          "id": 199,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_oldest_snapshot_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-oldest-snapshot-time\"",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-size-all-mem-tables\".\nIt shows the approximate size of all active, unflushed immutable, and\npinned immutable memtables in bytes, summed over all column families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 222
+          },
+          "id": 200,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_size_all_mem_tables",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-size-all-mem-tables\" - sum over column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric shows the currently used disk space in bytes on the volume\nwhich is used by RocksDB. Since RocksDB does not like out of disk\nspace scenarios, please make sure that there is enough free disk space\navailable at all times! Note that this metric is only available/populated on some platforms.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 230
+          },
+          "id": 201,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_total_disk_space",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Used disk space in bytes on volume used by RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric shows the currently used number of inodes on the disk volume\nused by RocksDB. Since RocksDB does not like out of disk space\nscenarios, please make sure that there are enough free inodes available\nat all times! Note that this metric is only available/populated on some platforms.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 230
+          },
+          "id": 202,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_total_inodes",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of used inodes on the volume used by RocksDB",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric exhibits the RocksDB metric \"rocksdb-total-sst-files-size\".\nIt shows the total size in bytes of all SST files, summed over all\ncolumn families.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 238
+          },
+          "id": 203,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rocksdb_total_sst_files_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "RocksDB metric \"rocksdb-total-sst-files-size\" - sum over all column families",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of connections in pool. There are two pools, one for the\nagency communication with label `AgencyComm` and one for the other\ncluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 238
+          },
+          "id": 206,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_connection_connections_current",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of connections in pool",
+          "type": "graph"
+        }
+      ],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 204,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of connections created for connection pool. There are\ntwo pools, one for the agency communication with label `AgencyComm`\nand one for the other cluster internal communication with label\n`ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "id": 205,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_connections_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of connections created for connection pool",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "id": 208,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "id": 207,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_connection_pool_lease_time_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of failed connection leases. There are two pools, one for\nthe agency communication with label `AgencyComm` and one for the other\ncluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "id": 210,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_leases_failed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of failed connection leases",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 209,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_sum[60s]) / rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "id": 214,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of successful connection leases from connection pool.\nThere are two pools, one for the agency communication with label\n`AgencyComm` and one for the other cluster internal communication with\nlabel `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 31
+          },
+          "id": 211,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_leases_successful_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of successful connection leases from connection pool",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 31
+          },
+          "id": 216,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests forwarded to another coordinator",
+          "type": "graph"
+        }
+      ],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 212,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 213,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agencycomm_request_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Number of internal requests that have timed out. This metric is increased\nwhenever any cluster-internal request executed in the underlying connection\npool runs into a timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 218,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_request_timeouts_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of internal requests that have timed out",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 215,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_sum[60s]) / rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 222,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated total time for creating V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram providing the round-trip time of internal requests as a percentage \nof the respective request timeout.\nThis metric will provide values between 0 and 100.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 217,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_network_request_duration_as_percentage_of_timeout",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Internal request round-trip time as a percentage of timeout",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 224,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter failures",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of outgoing internal requests in flight. This metric is increased\nwhenever any cluster-internal request is about to be sent via the underlying \nconnection pool, and is decreased whenever a response for such a request is\nreceived or the request runs into a timeout.\nThis metric provides an estimate of the fan-out of operations. For example,\na user operation on a collection with a single shard will normally lead to\na single internal request (plus replication), whereas an operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 219,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_network_requests_in_flight",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of outgoing internal requests in flight",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 226,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context exit events",
+          "type": "graph"
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 220,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 221,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever created",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This reflects the current number of callbacks the local `AgencyCache`\nhas registered.\nThis metric was named `arangodb_agency_cache_callback_count` in\nprevious versions of ArangoDB.\nNote that on single servers this metrics will only have a non-zero value\nin \"active failover\" deployment mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 231,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_cache_callback_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of entries in agency cache callbacks table",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 223,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever destroyed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric was named `arangodb_agency_callback_registered` in previous versions \nof ArangoDB.\nNote that on single servers this metrics will only have a non-zero value\nin \"active failover\" deployment mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 233,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_callback_registered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of agency callbacks ever registered",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 225,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter events",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency RAFT commit time histogram. Provides a distribution\nof commit times for all agency write operations.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "id": 235,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_commit_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency RAFT commit histogram",
+          "type": "heatmap"
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 227,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This measures the time an agency follower needs for individual\nappend operations resulting from `AppendEntriesRPC` requests.\nEvery event contributes a measurement to the histogram, which\nalso exposes the number of events and the total sum of all\nmeasurements.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 228,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_append_hist_total_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency RAFT follower append time histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "This measures the time an agency follower needs for individual\nappend operations resulting from `AppendEntriesRPC` requests.\nEvery event contributes a measurement to the histogram, which\nalso exposes the number of events and the total sum of all\nmeasurements.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 229,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_append_hist_total_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency RAFT follower append time histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This measures the time an agency follower needs for individual\nappend operations resulting from `AppendEntriesRPC` requests.\nEvery event contributes a measurement to the histogram, which\nalso exposes the number of events and the total sum of all\nmeasurements.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 230,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_append_hist_total_sum[60s]) / rate(arangodb_agency_append_hist_total_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency RAFT follower append time histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency RAFT commit time histogram. Provides a distribution\nof commit times for all agency write operations.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 237,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_commit_hist_sum[60s]) / rate(arangodb_agency_commit_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency RAFT commit histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This metric reflects the current number of agency callbacks being\nregistered, including agency cache callbacks.\nThis metric was named `arangodb_agency_callback_count` in previous versions \nof ArangoDB.\nNote that on single servers this metrics will only have a non-zero value\nin \"active failover\" deployment mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 232,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_callback_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of agency callbacks registered",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency compaction time histogram. Provides a distribution\nof agency compaction run times. Compactions are triggered after\n`--agency.compaction-keep-size` entries have accumulated in the\nRAFT log.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 239,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_compaction_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency compaction time histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of entries in agency client id lookup table.\nThe lookup table is used internally for agency inquire operations\nand should be compacted at the same time when the agency's in-memory\nlog is compacted. \n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 234,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_client_lookup_table_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of entries in agency client id lookup table",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This agent's commit index (i.e. the index until it has advanced in \nthe agency's RAFT protocol).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 241,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_local_commit_index",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "This agent's commit index",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency RAFT commit time histogram. Provides a distribution\nof commit times for all agency write operations.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 236,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_commit_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency RAFT commit histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of agency read operations with no leader or on followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 243,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_read_no_leader_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency read operations with no leader or on followers",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency compaction time histogram. Provides a distribution\nof agency compaction run times. Compactions are triggered after\n`--agency.compaction-keep-size` entries have accumulated in the\nRAFT log.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 238,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_compaction_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency compaction time histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Counter for FailedServer jobs. This counter is increased whenever a \nsupervision run encounters a failed server and starts a FailedServer job.\nThis metric was named `arangodb_agency_supervision_failed_server_count`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 245,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_failed_server_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Counter for FailedServer jobs",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency compaction time histogram. Provides a distribution\nof agency compaction run times. Compactions are triggered after\n`--agency.compaction-keep-size` entries have accumulated in the\nRAFT log.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 58
+          },
+          "id": 240,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_compaction_hist_sum[60s]) / rate(arangodb_agency_compaction_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency compaction time histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision runtime histogram. A new value is recorded for each\nrun of the supervision.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 58
+          },
+          "id": 247,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision runtime histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Size of the agency's in-memory part of replicated log in bytes.\nThe replicated log will grow in memory until a certain number of\nlog entries have been accumulated. Then the in-memory log will\nbe compacted. The number of in-memory log entries to keep before\nlog compaction kicks in can be controlled via the startup option\n` --agency.compaction-keep-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 66
+          },
+          "id": 242,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_log_size_bytes",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency replicated log size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision replication time histogram. Whenever the agency\nsupervision carries out changes, it will write them to the leader's log \nand replicate the changes to followers. This metric provides a histogram\nof the time it took to replicate the supervision changes to followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 66
+          },
+          "id": 249,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_supervision_runtime_wait_for_replication_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision wait for replication time",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Number of agency read operations which were successful (i.e. completed\nwithout any error). Successful reads can only be executed on the leader, so\nthis metric is supposed to increase only on agency leaders, but not on\nfollowers. Read requests that are executed on followers will be rejected\nand can be tracked via the metric `arangodb_agency_read_no_leader_total`.\nThis metric was named `arangodb_agency_read_ok` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 74
+          },
+          "id": 244,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_read_ok_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of successful agency read operations",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision replication time histogram. Whenever the agency\nsupervision carries out changes, it will write them to the leader's log \nand replicate the changes to followers. This metric provides a histogram\nof the time it took to replicate the supervision changes to followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 74
+          },
+          "id": 251,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_runtime_wait_for_replication_msec_sum[60s]) / rate(arangodb_agency_supervision_runtime_wait_for_replication_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision wait for replication time (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision runtime histogram. A new value is recorded for each\nrun of the supervision.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 82
+          },
+          "id": 246,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_supervision_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision runtime histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Agency write time histogram. This histogram provides the distribution\nof the times spent in agency write operations, in milliseconds. This only\nincludes the time required to write the data into the leader's log, but\ndoes not include the time required to replicate the writes to the followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 82
+          },
+          "id": 253,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_write_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency write time histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision runtime histogram. A new value is recorded for each\nrun of the supervision.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 90
+          },
+          "id": 248,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_runtime_msec_sum[60s]) / rate(arangodb_agency_supervision_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision runtime histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency write time histogram. This histogram provides the distribution\nof the times spent in agency write operations, in milliseconds. This only\nincludes the time required to write the data into the leader's log, but\ndoes not include the time required to replicate the writes to the followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 90
+          },
+          "id": 255,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_write_hist_sum[60s]) / rate(arangodb_agency_write_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency write time histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision replication time histogram. Whenever the agency\nsupervision carries out changes, it will write them to the leader's log \nand replicate the changes to followers. This metric provides a histogram\nof the time it took to replicate the supervision changes to followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 98
+          },
+          "id": 250,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_runtime_wait_for_replication_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision wait for replication time (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of agency write operations which were successful (i.e. completed\nwithout any error). Successful writes can only be executed on the leader, so\nthis metric is supposed to increase only on agency leaders, but not on\nfollowers. Write requests that are executed on followers will be rejected\nand can be tracked via the metric `arangodb_agency_write_no_leader_total`.\nThis metric was named `arangodb_agency_write_ok` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 98
+          },
+          "id": 257,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_write_ok_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of successful agency write operations",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The Agency's current term.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 106
+          },
+          "id": 252,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_term",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency's term",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of jobs submitted to the scheduler.\nCalculating the difference between arangodb_scheduler_jobs_submitted_total\nand arangodb_scheduler_jobs_dequeued_total gives the total number of\ncurrently queued jobs.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 106
+          },
+          "id": 262,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_jobs_submitted_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of jobs submitted to the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency write time histogram. This histogram provides the distribution\nof the times spent in agency write operations, in milliseconds. This only\nincludes the time required to write the data into the leader's log, but\ndoes not include the time required to replicate the writes to the followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 114
+          },
+          "id": 254,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_write_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency write time histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's low priority queue.\nThe capacity of the low priority queue can be configured via the startup\noption `--server.maximal-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 114
+          },
+          "id": 264,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_low_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the low priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of agency write operations with no leader or on followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 122
+          },
+          "id": 256,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_write_no_leader_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency write operations with no leader or on followers",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's medium priority queue.\nThe capacity of the medium priority queue can be configured via the startup\noption `--server.prio2-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 122
+          },
+          "id": 266,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_medium_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the medium priority queue in the scheduler",
+          "type": "graph"
+        }
+      ],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 258,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's high priority queue.\nThe capacity of the high priority queue can be configured via the startup\noption `--server.prio1-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 259,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_high_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the high priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total number of jobs dequeued from all scheduler queues.\nCalculating the difference between arangodb_scheduler_jobs_submitted_total\nand arangodb_scheduler_jobs_dequeued_total gives the total number of\ncurrently queued jobs.\nCalculating the difference between arangodb_scheduler_jobs_dequeued_total\nand arangodb_scheduler_jobs_done_total gives the number of jobs currently\nbeing processed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 260,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_jobs_dequeued_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of jobs dequeued",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total number of queue jobs done.\nCalculating the difference between arangodb_scheduler_jobs_dequeued_total\nand arangodb_scheduler_jobs_done_total gives the total number of jobs\ncurrently being processed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 261,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_jobs_done_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of queue jobs done",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of worker threads currently started. Worker threads can be started\nand stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 268,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_worker_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of worker threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Last recorded dequeue time for a low priority queue item, i.e., the amount of\ntime the job was sitting in the queue. If there is nothing to do for a long\ntime, this metric will be reset to zero.\nA large value for this metric indicates that the server is under heavy load\nand low priority jobs cannot be dequeued in a timely manner\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 263,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_low_prio_queue_last_dequeue_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Last recorded dequeue time for a low priority queue item",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of low priority jobs currently being processed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 270,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_ongoing_low_prio",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of ongoing RestHandlers coming from the low prio queue",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's maintenance priority\nqueue. These are the jobs with the highest priority and are mainly used for\ncluster internal operations. The capacity of the maintenance priority queue\ncan be configured via the startup option `--server.scheduler-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 265,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_maintenance_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the maintenance priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total number of currently queued jobs in all queues.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 272,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Server's internal queue length",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of worker threads currently working on some job or spinning while\nwaiting for new work (i.e., not sleeping).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 267,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_awake_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of awake worker threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total accumulated number of scheduler threads stopped. Worker threads can be\nstarted and stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 274,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_threads_stopped_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated total number of scheduler threads stopped",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The current number of threads actually working on some job (i.e., not\nspinning while waiting for new work).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 269,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_working_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of working threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of `Plan` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadPlan` internal method. Provides a\ndistribution of all loading times for the `Plan`\nsection of the agency data. The `Plan` section normally gets\nloaded on server startup, and then gets reloaded on servers \nonly for any databases in which there have been recent structural \nchanges (i.e. DDL changes).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 279,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_load_plan_runtime_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "`Plan` loading runtimes",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Number of tasks dropped because the queue was already full. The queue capacities\ncan be configured via the startup options `--server.scheduler-queue-size`,\n`--server.prio1-size`, `--server.prio2-size` and `--server.maximal-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 271,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_queue_full_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of tasks dropped and not added to internal queue",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of `Plan` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadPlan` internal method. Provides a\ndistribution of all loading times for the `Plan`\nsection of the agency data. The `Plan` section normally gets\nloaded on server startup, and then gets reloaded on servers \nonly for any databases in which there have been recent structural \nchanges (i.e. DDL changes).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 281,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_load_plan_runtime_sum[60s]) / rate(arangodb_load_plan_runtime_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "`Plan` loading runtimes (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total accumulated number of scheduler threads started. Worker threads can be\nstarted and stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 273,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_threads_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total accumulated number of scheduler threads started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric counts the number of actions that have been created but found to\nbe a duplicate of a already queued action.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 283,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_duplicate_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Counter of actions that have been discarded because of a duplicate",
+          "type": "graph"
+        }
+      ],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 275,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Histogram of `Current` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadCurrent` internal method. Provides a\ndistribution of all loading times for the `Current`\nsection of the agency data. The `Current` section gets\nloaded on server startup, and then gets reloaded on servers \nonly for any databases in which there have been recent structural \nchanges (i.e. DDL changes).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 276,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_load_current_runtime_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "`Current` loading runtimes",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of `Current` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadCurrent` internal method. Provides a\ndistribution of all loading times for the `Current`\nsection of the agency data. The `Current` section gets\nloaded on server startup, and then gets reloaded on servers \nonly for any databases in which there have been recent structural \nchanges (i.e. DDL changes).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 277,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_load_current_runtime_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "`Current` loading runtimes (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of `Current` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadCurrent` internal method. Provides a\ndistribution of all loading times for the `Current`\nsection of the agency data. The `Current` section gets\nloaded on server startup, and then gets reloaded on servers \nonly for any databases in which there have been recent structural \nchanges (i.e. DDL changes).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "hiddenSeries": false,
+          "id": 278,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_load_current_runtime_sum[60s]) / rate(arangodb_load_current_runtime_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "`Current` loading runtimes (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric tracks the time actions spend waiting in the queue in a histogram.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 285,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_maintenance_action_queue_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time spent in the queue before execution for maintenance actions",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of `Plan` loading runtimes, i.e. the runtimes\nof the `ClusterInfo::loadPlan` internal method. Provides a\ndistribution of all loading times for the `Plan`\nsection of the agency data. The `Plan` section normally gets\nloaded on server startup, and then gets reloaded on servers \nonly for any databases in which there have been recent structural \nchanges (i.e. DDL changes).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "hiddenSeries": false,
+          "id": 280,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_load_plan_runtime_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "`Plan` loading runtimes (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric tracks the time actions spend waiting in the queue in a histogram.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "hiddenSeries": false,
+          "id": 287,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_queue_time_msec_sum[60s]) / rate(arangodb_maintenance_action_queue_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time spent in the queue before execution for maintenance actions (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric counts the number of actions that are done and have been removed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 282,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_done_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Counter of actions that are done and have been removed from the registry",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric tracks the time actions spend executing in a histogram.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 289,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_maintenance_action_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time spent executing a maintenance action",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThose action can fail for different reasons. This metric counts the failed\nactions and can thus provide hints to investigate a malfunction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 284,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_failure_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Failure counter for the maintenance actions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric tracks the time actions spend executing in a histogram.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 291,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_runtime_msec_sum[60s]) / rate(arangodb_maintenance_action_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time spent executing a maintenance action (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric tracks the time actions spend waiting in the queue in a histogram.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 286,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_queue_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time spent in the queue before execution for maintenance actions (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of individual agency syncs in a histogram.\nDuring DDL operations the runtime can increase but should generally be below\n1s.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 293,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_agency_sync_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent on agency sync (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric counts the number of actions that are queued or active.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 288,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_registered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Counter of actions that have been registered in the action registry",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of phase1 of an agency sync. Phase1 calculates\nthe difference between the local and the target state.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 295,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_maintenance_phase1_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Phase 1 runtime histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric tracks the time actions spend executing in a histogram.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 290,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time spent executing a maintenance action (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of phase1 of an agency sync. Phase1 calculates\nthe difference between the local and the target state.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 297,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_phase1_runtime_msec_sum[60s]) / rate(arangodb_maintenance_phase1_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Phase 1 runtime histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of individual agency syncs in a histogram.\nDuring DDL operations the runtime can increase but should generally be below\n1s.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 292,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_maintenance_agency_sync_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent on agency sync",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of phase2 of an agency sync. Phase2 calculates\nwhat actions to execute given the difference of the local and target state.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 299,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_phase2_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Phase 2 runtime histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of individual agency syncs in a histogram.\nDuring DDL operations the runtime can increase but should generally be below\n1s.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 294,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_agency_sync_runtime_msec_sum[60s]) / rate(arangodb_maintenance_agency_sync_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent on agency sync (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of phase1 of an agency sync. Phase1 calculates\nthe difference between the local and the target state.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 296,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_phase1_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Phase 1 runtime histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of phase2 of an agency sync. Phase2 calculates\nwhat actions to execute given the difference of the local and target state.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 298,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_maintenance_phase2_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Phase 2 runtime histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of phase2 of an agency sync. Phase2 calculates\nwhat actions to execute given the difference of the local and target state.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 300,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_phase2_runtime_msec_sum[60s]) / rate(arangodb_maintenance_phase2_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maintenance Phase 2 runtime histogram (average per second)",
+          "type": "graph"
+        }
+      ],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, all metrics",
+  "uid": "hvjLFeXGz",
+  "version": 1
+}

--- a/ArangoDB_3.8/ArangoDB_3.8_for_Oasis_customers-1619089074406.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_for_Oasis_customers-1619089074406.json
@@ -1,0 +1,4441 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of AQL queries finished",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Current number of AQL queries executing",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total memory limit for all AQL queries combined",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 11,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 17,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 18,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total amount of time it took to acquire collection/shard locks for\nwrite operations, summed up for all collections/shards. Will not be increased \nfor any read operations.\nThe value is measured in microseconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_micros_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total amount of collection lock acquisition time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of transactions using sequential locking of collections to avoid deadlocking.\nBy default, a coordinator will try to lock all shards of a collection in parallel.\nThis approach is normally fast but can cause deadlocks with other transactions that\nlock the same shards in a different order. In case such a deadlock is detected, the\ncoordinator will abort the lock round and start a new one that locks all shards in\nsequential order. This will avoid deadlocks, but has a higher setup overhead.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_sequential_mode_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions using sequential locking of collections to avoid deadlocking",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection exclusive locks.\nThis counter will be increased whenever an exclusive collection lock\ncannot be acquired within the configured lock timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 21,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_exclusive_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection exclusive locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection write locks.\nThis counter will be increased whenever a collection write lock\ncannot be acquired within the configured lock timeout. \nThis can only happen if writes on a collection are locked out by\nother operations on the collection that use an exclusive lock. Writes\nare not locked out by other, non-exclusively locked writes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 22,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_write_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection write locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 23,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 25,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 26,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 27,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 29,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 30,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 32,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 33,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 35,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 36,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 38,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 39,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 41,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations (insert, update, replace, remove) on\nleaders, excluding writes by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 42,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 99
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 99
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 107
+          },
+          "id": 45,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 107
+          },
+          "id": 46,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 47,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 48,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 49,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 50,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 51,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 53,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 54,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 55,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 56,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 57,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 58,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 59,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 60,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 61,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 62,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 63,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 64,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 66,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 67,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 70,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 99,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 100,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations by synchronous\nreplication on followers. Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations by synchronous replication.\nThis metric is only present if the option\n`--server.export-read-write-metrics` is set to `true`.\nTotal number of document write operations (insert, update, replace, remove)\nexecuted by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Measures the time required to clone the existing leader copy of the data onto a new replica shard.\nWill only be measured on the follower server. This time is expected to increase whenever new followers\nare created, e.g. increasing replication factor, shard redistribution.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 103,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of requests required to transport data to this server,\nas a replica for a shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 104,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of bytes replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The accumulated time the follower waited for the leader to send\nthe data is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 106,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication requests in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of data transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 107,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests used in initial asynchronous replication phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. Whenever there is a communication issue between the follower and\nthe leader of the shard it will be counted here for the follower. This communication\nissues cover failed connections or http errors, but they also cover invalid or\nunexpected data formats revieved on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 108,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_failed_connects_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of failed connection attempts and response errors during initial asynchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for replication key\nchunks determination requests, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the initial step of getting\nthe checksums for the key chunks.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 109,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_chunks_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication key chunks determination requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for requesting actual\ndocuments for the initial replication, in milliseconds. This is part\nof the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the final step of actually\ngetting the needed documents.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 110,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_docs_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to request replication docs data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Accumulated time needed to apply replication initial sync insertions.\nThis counter exhibits the accumulated wait time for actually inserting\ndocuments for the initial synchronization, in milliseconds. This is\npart of the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the actual insertion of\nreplicated documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 111,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_insert_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync insertions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for fetching key\nlists for a chunk, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the second step of getting\nlists of key/revision pairs for each chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 112,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_keys_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for removing local\ndocuments during initial synchronization of a shard on the follower,\nin milliseconds. This is part of the older (pre 3.8) initial\nreplication protocol, which might still be used in 3.8 for collections\nwhich have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the intermediate step of\nremoving unneeded documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 113,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_remove_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync removals",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of bytes received\nfor initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates number of bytes received for all three steps.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 114,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated amount of bytes received in initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents inserted on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents inserted in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "id": 115,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_inserted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents inserted by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents removed on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents removed in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 61
+          },
+          "id": 116,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_removed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents removed by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents fetched on the\nfollower from the leader during initial synchronization of shards.\nThis is part of the older (pre 3.8) initial replication protocol,\nwhich might still be used in 3.8 for collections which have been\ncreated by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents fetched from the\nleader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 69
+          },
+          "id": 117,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requested_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents requested by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of times documents have been\nfetched on the follower from the leader during initial synchronization\nof shards. This is part of the older (pre 3.8) initial replication\nprotocol, which might still be used in 3.8 for collections which have\nbeen created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of times documents have been\nfetched from the leader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 69
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync docs requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of keys requests for\ninitial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric counts the number of times the follower fetches a list of\nkeys for some chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 77
+          },
+          "id": 119,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_keys_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of all synchronous replication operation requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 77
+          },
+          "id": 120,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_number_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total time needed for all synchronous replication requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 85
+          },
+          "id": 121,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed for all synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated time needed to locally process the continuous\nreplication log on a follower received from a replication\nleader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 85
+          },
+          "id": 122,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication tailing data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of bytes received from a leader for replication tailing requests. The higher the amount of bytes is, the more data is being processed afterwards on the follower dbserver.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 93
+          },
+          "id": 123,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of bytes received for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of replication tailing document inserts/replaces processed on a follower.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 93
+          },
+          "id": 124,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of replication tailing document inserts/replaces processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing markers processed on a follower\ndbserver. Markers are specific operations which are part of the\nwrite-ahead log (WAL). Example actions which are being used in\nmarkers: Create or drop a database. Create, drop, rename, change\nor truncate a collection. Create or drop an index. Create, drop,\nchange a view. Start, commit or abort a transaction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 101
+          },
+          "id": 125,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_markers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing markers processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The amount of document removal based marker operations on a\nfollower dbserver.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 101
+          },
+          "id": 126,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_removals_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing document removals processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of network replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 109
+          },
+          "id": 127,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 109
+          },
+          "id": 128,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 117
+          },
+          "id": 129,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 117
+          },
+          "id": 130,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 125
+          },
+          "id": 131,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of times a mismatching shard checksum was detected when\nsyncing shards. This is a very special metric which is rarely used.\nWhen followers of shards get in sync with their leaders, just when\neverything is completed a final checksum is taken as an additional\nprecaution. If this checksum differs between leader an follower, the\nresync process starts from scratch.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 125
+          },
+          "id": 132,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_sync_wrong_checksum_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a mismatching shard checksum was detected when syncing shards",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 133,
+      "panels": [],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 134,
+      "panels": [],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 135,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 136,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of requests forwarded to another coordinator",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 139,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Accumulated total time for creating V8 contexts",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 137,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 138,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 contexts ever created",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 141,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context enter failures",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 140,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 contexts ever destroyed",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 143,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context exit events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 142,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter events",
+          "type": "graph"
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 144,
+      "panels": [],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 145,
+      "panels": [],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 146,
+      "panels": [],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, for Oasis customers",
+  "uid": "9fj9KeuMk",
+  "version": 1
+}

--- a/ArangoDB_3.8/ArangoDB_3.8_for_Oasis_on_call-1619089134192.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_for_Oasis_on_call-1619089134192.json
@@ -1,0 +1,5336 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 4,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_heartbeat_send_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time required to send a heartbeat",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_sum[60s]) / rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 7,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 8,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of AQL queries finished",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of AQL queries executing",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory limit for all AQL queries combined",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 11,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 17,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 18,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection exclusive locks.\nThis counter will be increased whenever an exclusive collection lock\ncannot be acquired within the configured lock timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 23,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_exclusive_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection exclusive locks",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 21,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total amount of time it took to acquire collection/shard locks for\nwrite operations, summed up for all collections/shards. Will not be increased \nfor any read operations.\nThe value is measured in microseconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 22,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_micros_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total amount of collection lock acquisition time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 25,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection write locks.\nThis counter will be increased whenever a collection write lock\ncannot be acquired within the configured lock timeout. \nThis can only happen if writes on a collection are locked out by\nother operations on the collection that use an exclusive lock. Writes\nare not locked out by other, non-exclusively locked writes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_write_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection write locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 27,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 26,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 29,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 30,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 33,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 32,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 35,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 36,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 39,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 38,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 41,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 42,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 45,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations (insert, update, replace, remove) on\nleaders, excluding writes by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 47,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 99
+          },
+          "id": 46,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 99
+          },
+          "id": 51,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 107
+          },
+          "id": 48,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 107
+          },
+          "id": 53,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 49,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 50,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 55,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 57,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 54,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 59,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 56,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 61,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 58,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 63,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 60,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 62,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 67,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 64,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 66,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 70,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of intermediate commits performed in transactions.\nAn intermediate commit happens if a logical transaction needs to be\nsplit into multiple physical transaction because of the volume of data\nhandled in the transaction. The thresholds for when to perform an\nintermediate commit can be controlled by startup options \n`--rocksdb.intermediate-commit-count` (number of write operations after\nwhich an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n(cumulated size of write operations after which an intermediate commit is triggered).\nThe values can also be overridden for individual transactions.\nThis metric was named `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_intermediate_commits_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of intermediate commits performed in transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 99,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations by synchronous replication.\nThis metric is only present if the option\n`--server.export-read-write-metrics` is set to `true`.\nTotal number of document write operations (insert, update, replace, remove)\nexecuted by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 100,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of requests required to transport data to this server,\nas a replica for a shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 107,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of bytes replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 212
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The accumulated time the follower waited for the leader to send\nthe data is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 212
+          },
+          "id": 109,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication requests in initial asynchronous phase",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 103,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations by synchronous\nreplication on followers. Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 104,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. Whenever there is a communication issue between the follower and\nthe leader of the shard it will be counted here for the follower. This communication\nissues cover failed connections or http errors, but they also cover invalid or\nunexpected data formats revieved on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 111,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_failed_connects_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of failed connection attempts and response errors during initial asynchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Measures the time required to clone the existing leader copy of the data onto a new replica shard.\nWill only be measured on the follower server. This time is expected to increase whenever new followers\nare created, e.g. increasing replication factor, shard redistribution.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 106,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for requesting actual\ndocuments for the initial replication, in milliseconds. This is part\nof the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the final step of actually\ngetting the needed documents.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 113,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_docs_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to request replication docs data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 108,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for fetching key\nlists for a chunk, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the second step of getting\nlists of key/revision pairs for each chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 115,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_keys_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of data transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 110,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests used in initial asynchronous replication phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of bytes received\nfor initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates number of bytes received for all three steps.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 117,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated amount of bytes received in initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for replication key\nchunks determination requests, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the initial step of getting\nthe checksums for the key chunks.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 112,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_chunks_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication key chunks determination requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents removed on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents removed in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 119,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_removed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents removed by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Accumulated time needed to apply replication initial sync insertions.\nThis counter exhibits the accumulated wait time for actually inserting\ndocuments for the initial synchronization, in milliseconds. This is\npart of the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the actual insertion of\nreplicated documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 114,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_insert_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync insertions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of times documents have been\nfetched on the follower from the leader during initial synchronization\nof shards. This is part of the older (pre 3.8) initial replication\nprotocol, which might still be used in 3.8 for collections which have\nbeen created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of times documents have been\nfetched from the leader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 121,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync docs requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for removing local\ndocuments during initial synchronization of a shard on the follower,\nin milliseconds. This is part of the older (pre 3.8) initial\nreplication protocol, which might still be used in 3.8 for collections\nwhich have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the intermediate step of\nremoving unneeded documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 116,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_remove_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync removals",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of all synchronous replication operation requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 123,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_number_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents inserted on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents inserted in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_inserted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents inserted by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated time needed to locally process the continuous\nreplication log on a follower received from a replication\nleader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 61
+          },
+          "id": 125,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication tailing data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents fetched on the\nfollower from the leader during initial synchronization of shards.\nThis is part of the older (pre 3.8) initial replication protocol,\nwhich might still be used in 3.8 for collections which have been\ncreated by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents fetched from the\nleader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 69
+          },
+          "id": 120,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requested_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents requested by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of replication tailing document inserts/replaces processed on a follower.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 69
+          },
+          "id": 127,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of replication tailing document inserts/replaces processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of keys requests for\ninitial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric counts the number of times the follower fetches a list of\nkeys for some chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 77
+          },
+          "id": 122,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_keys_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The amount of document removal based marker operations on a\nfollower dbserver.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 77
+          },
+          "id": 129,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_removals_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing document removals processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total time needed for all synchronous replication requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 85
+          },
+          "id": 124,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed for all synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 85
+          },
+          "id": 131,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of bytes received from a leader for replication tailing requests. The higher the amount of bytes is, the more data is being processed afterwards on the follower dbserver.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 93
+          },
+          "id": 126,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of bytes received for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 93
+          },
+          "id": 133,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing markers processed on a follower\ndbserver. Markers are specific operations which are part of the\nwrite-ahead log (WAL). Example actions which are being used in\nmarkers: Create or drop a database. Create, drop, rename, change\nor truncate a collection. Create or drop an index. Create, drop,\nchange a view. Start, commit or abort a transaction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 101
+          },
+          "id": 128,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_markers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing markers processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of times a mismatching shard checksum was detected when\nsyncing shards. This is a very special metric which is rarely used.\nWhen followers of shards get in sync with their leaders, just when\neverything is completed a final checksum is taken as an additional\nprecaution. If this checksum differs between leader an follower, the\nresync process starts from scratch.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 101
+          },
+          "id": 135,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_sync_wrong_checksum_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a mismatching shard checksum was detected when syncing shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of network replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 109
+          },
+          "id": 130,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stalled (slowed) write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 109
+          },
+          "id": 140,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stalls_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stalled (slowed) write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 117
+          },
+          "id": 132,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of connections in pool. There are two pools, one for the\nagency communication with label `AgencyComm` and one for the other\ncluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 117
+          },
+          "id": 144,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_connection_connections_current",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of connections in pool",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 125
+          },
+          "id": 134,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 136,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the collection/shard lock acquisition times. Locks will be acquired for\nall write operations, but not for read operations.\nThe values here are measured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 6
+          },
+          "id": 137,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_lock_acquisition_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Collection lock acquisition time histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the collection/shard lock acquisition times. Locks will be acquired for\nall write operations, but not for read operations.\nThe values here are measured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "id": 138,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Collection lock acquisition time histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the collection/shard lock acquisition times. Locks will be acquired for\nall write operations, but not for read operations.\nThe values here are measured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 139,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_time_sum[60s]) / rate(arangodb_collection_lock_acquisition_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Collection lock acquisition time histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 146,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stopped write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high,\nbut write stops are considerably worse, since they can lead to service\nunavailability.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 141,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stops_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stopped write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of failed connection leases. There are two pools, one for\nthe agency communication with label `AgencyComm` and one for the other\ncluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 148,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_leases_failed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of failed connection leases",
+          "type": "graph"
+        }
+      ],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 142,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of connections created for connection pool. There are\ntwo pools, one for the agency communication with label `AgencyComm`\nand one for the other cluster internal communication with label\n`ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "id": 143,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_connections_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of connections created for connection pool",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "id": 152,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "id": 145,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_connection_pool_lease_time_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "id": 154,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests forwarded to another coordinator",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 147,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_sum[60s]) / rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of outgoing internal requests in flight. This metric is increased\nwhenever any cluster-internal request is about to be sent via the underlying \nconnection pool, and is decreased whenever a response for such a request is\nreceived or the request runs into a timeout.\nThis metric provides an estimate of the fan-out of operations. For example,\na user operation on a collection with a single shard will normally lead to\na single internal request (plus replication), whereas an operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "id": 156,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_network_requests_in_flight",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of outgoing internal requests in flight",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of successful connection leases from connection pool.\nThere are two pools, one for the agency communication with label\n`AgencyComm` and one for the other cluster internal communication with\nlabel `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 31
+          },
+          "id": 149,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_leases_successful_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of successful connection leases from connection pool",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 31
+          },
+          "id": 161,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter failures",
+          "type": "graph"
+        }
+      ],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 150,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 151,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agencycomm_request_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 163,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context exit events",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 153,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_sum[60s]) / rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of agency read operations which were successful (i.e. completed\nwithout any error). Successful reads can only be executed on the leader, so\nthis metric is supposed to increase only on agency leaders, but not on\nfollowers. Read requests that are executed on followers will be rejected\nand can be tracked via the metric `arangodb_agency_read_no_leader_total`.\nThis metric was named `arangodb_agency_read_ok` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 168,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_read_ok_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of successful agency read operations",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of internal requests that have timed out. This metric is increased\nwhenever any cluster-internal request executed in the underlying connection\npool runs into a timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 155,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_request_timeouts_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of internal requests that have timed out",
+          "type": "graph"
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 157,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 158,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever created",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 159,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated total time for creating V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 160,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever destroyed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision runtime histogram. A new value is recorded for each\nrun of the supervision.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 170,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision runtime histogram (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 162,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter events",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of agency write operations which were successful (i.e. completed\nwithout any error). Successful writes can only be executed on the leader, so\nthis metric is supposed to increase only on agency leaders, but not on\nfollowers. Write requests that are executed on followers will be rejected\nand can be tracked via the metric `arangodb_agency_write_no_leader_total`.\nThis metric was named `arangodb_agency_write_ok` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "id": 172,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_write_ok_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of successful agency write operations",
+          "type": "graph"
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 164,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This agent's commit index (i.e. the index until it has advanced in \nthe agency's RAFT protocol).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 165,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_local_commit_index",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "This agent's commit index",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Size of the agency's in-memory part of replicated log in bytes.\nThe replicated log will grow in memory until a certain number of\nlog entries have been accumulated. Then the in-memory log will\nbe compacted. The number of in-memory log entries to keep before\nlog compaction kicks in can be controlled via the startup option\n` --agency.compaction-keep-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 166,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_agency_log_size_bytes",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency replicated log size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of agency read operations with no leader or on followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 167,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_read_no_leader_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency read operations with no leader or on followers",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's maintenance priority\nqueue. These are the jobs with the highest priority and are mainly used for\ncluster internal operations. The capacity of the maintenance priority queue\ncan be configured via the startup option `--server.scheduler-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 177,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_maintenance_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the maintenance priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision runtime histogram. A new value is recorded for each\nrun of the supervision.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 169,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agency_supervision_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision runtime histogram",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "The number of worker threads currently working on some job or spinning while\nwaiting for new work (i.e., not sleeping).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 179,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_awake_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of awake worker threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Agency supervision runtime histogram. A new value is recorded for each\nrun of the supervision.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 171,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agency_supervision_runtime_msec_sum[60s]) / rate(arangodb_agency_supervision_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Agency supervision runtime histogram (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The current number of threads actually working on some job (i.e., not\nspinning while waiting for new work).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 181,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_working_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of working threads",
+          "type": "graph"
+        }
+      ],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 173,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's high priority queue.\nThe capacity of the high priority queue can be configured via the startup\noption `--server.prio1-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 174,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_high_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the high priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Last recorded dequeue time for a low priority queue item, i.e., the amount of\ntime the job was sitting in the queue. If there is nothing to do for a long\ntime, this metric will be reset to zero.\nA large value for this metric indicates that the server is under heavy load\nand low priority jobs cannot be dequeued in a timely manner\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 175,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_low_prio_queue_last_dequeue_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Last recorded dequeue time for a low priority queue item",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's low priority queue.\nThe capacity of the low priority queue can be configured via the startup\noption `--server.maximal-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 176,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_low_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the low priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of tasks dropped because the queue was already full. The queue capacities\ncan be configured via the startup options `--server.scheduler-queue-size`,\n`--server.prio1-size`, `--server.prio2-size` and `--server.maximal-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 183,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_queue_full_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of tasks dropped and not added to internal queue",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of jobs currently queued on the scheduler's medium priority queue.\nThe capacity of the medium priority queue can be configured via the startup\noption `--server.prio2-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 178,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_medium_prio_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current queue length of the medium priority queue in the scheduler",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total accumulated number of scheduler threads started. Worker threads can be\nstarted and stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 185,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_threads_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total accumulated number of scheduler threads started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of worker threads currently started. Worker threads can be started\nand stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 180,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_worker_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of worker threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThose action can fail for different reasons. This metric counts the failed\nactions and can thus provide hints to investigate a malfunction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 189,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_failure_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Failure counter for the maintenance actions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of low priority jobs currently being processed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 182,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_ongoing_low_prio",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of ongoing RestHandlers coming from the low prio queue",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of individual agency syncs in a histogram.\nDuring DDL operations the runtime can increase but should generally be below\n1s.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 191,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_maintenance_agency_sync_runtime_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent on agency sync",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "The total number of currently queued jobs in all queues.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 184,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Server's internal queue length",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of individual agency syncs in a histogram.\nDuring DDL operations the runtime can increase but should generally be below\n1s.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 193,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_agency_sync_runtime_msec_sum[60s]) / rate(arangodb_maintenance_agency_sync_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent on agency sync (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total accumulated number of scheduler threads stopped. Worker threads can be\nstarted and stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 186,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_threads_stopped_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated total number of scheduler threads stopped",
+          "type": "graph"
+        }
+      ],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 187,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric counts the number of actions that are done and have been removed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 188,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_done_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Counter of actions that are done and have been removed from the registry",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. Actions are created, registered, queued and executed.\nOnce they are done they will eventually be removed.\n\nThis metric counts the number of actions that are queued or active.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "hiddenSeries": false,
+          "id": 190,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_action_registered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Counter of actions that have been registered in the action registry",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Database servers execute reconciliation actions to let the cluster converge\nto the desired state. To identify the target state differences in the meta\ndata store provided by the agency are investigated and local changes are\nreported. This process is called agency sync and is executed in regular\nintervals.\n\nThis metric tracks the runtime of individual agency syncs in a histogram.\nDuring DDL operations the runtime can increase but should generally be below\n1s.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "hiddenSeries": false,
+          "id": 192,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_maintenance_agency_sync_runtime_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total time spent on agency sync (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, for Oasis on call",
+  "uid": "aiPqF6uMz",
+  "version": 1
+}

--- a/ArangoDB_3.8/ArangoDB_3.8_for_application_developers-1619088948984.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_for_application_developers-1619088948984.json
@@ -1,0 +1,4570 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 4,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_heartbeat_send_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time required to send a heartbeat",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_sum[60s]) / rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 7,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 8,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of AQL queries finished",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of AQL queries executing",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory limit for all AQL queries combined",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 11,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 17,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 18,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of transactions using sequential locking of collections to avoid deadlocking.\nBy default, a coordinator will try to lock all shards of a collection in parallel.\nThis approach is normally fast but can cause deadlocks with other transactions that\nlock the same shards in a different order. In case such a deadlock is detected, the\ncoordinator will abort the lock round and start a new one that locks all shards in\nsequential order. This will avoid deadlocks, but has a higher setup overhead.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 23,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_sequential_mode_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions using sequential locking of collections to avoid deadlocking",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 21,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total amount of time it took to acquire collection/shard locks for\nwrite operations, summed up for all collections/shards. Will not be increased \nfor any read operations.\nThe value is measured in microseconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 22,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_micros_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total amount of collection lock acquisition time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection write locks.\nThis counter will be increased whenever a collection write lock\ncannot be acquired within the configured lock timeout. \nThis can only happen if writes on a collection are locked out by\nother operations on the collection that use an exclusive lock. Writes\nare not locked out by other, non-exclusively locked writes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 25,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_write_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection write locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection exclusive locks.\nThis counter will be increased whenever an exclusive collection lock\ncannot be acquired within the configured lock timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_exclusive_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection exclusive locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 27,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 26,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 29,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 30,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 33,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 32,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 35,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 36,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 39,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 38,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 41,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 42,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations (insert, update, replace, remove) on\nleaders, excluding writes by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 45,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 47,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 99
+          },
+          "id": 46,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 99
+          },
+          "id": 49,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 107
+          },
+          "id": 48,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 50,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 51,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 53,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 54,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 55,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 56,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 57,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 58,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 59,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 60,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 61,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 62,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 63,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 64,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 66,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 67,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 70,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of intermediate commits performed in transactions.\nAn intermediate commit happens if a logical transaction needs to be\nsplit into multiple physical transaction because of the volume of data\nhandled in the transaction. The thresholds for when to perform an\nintermediate commit can be controlled by startup options \n`--rocksdb.intermediate-commit-count` (number of write operations after\nwhich an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n(cumulated size of write operations after which an intermediate commit is triggered).\nThe values can also be overridden for individual transactions.\nThis metric was named `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_intermediate_commits_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of intermediate commits performed in transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 99,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 100,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 212
+          },
+          "id": 103,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 212
+          },
+          "id": 106,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 104,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 108,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 107,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stopped write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high,\nbut write stops are considerably worse, since they can lead to service\nunavailability.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 112,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stops_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stopped write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 109,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests forwarded to another coordinator",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 110,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stalled (slowed) write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 6
+          },
+          "id": 111,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stalls_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stalled (slowed) write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of outgoing internal requests in flight. This metric is increased\nwhenever any cluster-internal request is about to be sent via the underlying \nconnection pool, and is decreased whenever a response for such a request is\nreceived or the request runs into a timeout.\nThis metric provides an estimate of the fan-out of operations. For example,\na user operation on a collection with a single shard will normally lead to\na single internal request (plus replication), whereas an operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "id": 120,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_network_requests_in_flight",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of outgoing internal requests in flight",
+          "type": "graph"
+        }
+      ],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 113,
+      "panels": [],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 114,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 115,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agencycomm_request_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 116,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Request time for Agency requests (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 117,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_sum[60s]) / rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Request time for Agency requests (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 125,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context enter failures",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Number of internal requests that have timed out. This metric is increased\nwhenever any cluster-internal request executed in the underlying connection\npool runs into a timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 119,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_request_timeouts_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of internal requests that have timed out",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 127,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context exit events",
+          "type": "graph"
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 121,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 122,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 contexts ever created",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 123,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Accumulated total time for creating V8 contexts",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 124,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 contexts ever destroyed",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "The current number of threads actually working on some job (i.e., not\nspinning while waiting for new work).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 133,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_working_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Current number of working threads",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "hiddenSeries": false,
+          "id": 126,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context enter events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Number of tasks dropped because the queue was already full. The queue capacities\ncan be configured via the startup options `--server.scheduler-queue-size`,\n`--server.prio1-size`, `--server.prio2-size` and `--server.maximal-queue-size`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "hiddenSeries": false,
+          "id": 135,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_scheduler_queue_full_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of tasks dropped and not added to internal queue",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 128,
+      "panels": [],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 129,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Last recorded dequeue time for a low priority queue item, i.e., the amount of\ntime the job was sitting in the queue. If there is nothing to do for a long\ntime, this metric will be reset to zero.\nA large value for this metric indicates that the server is under heavy load\nand low priority jobs cannot be dequeued in a timely manner\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "hiddenSeries": false,
+          "id": 130,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_low_prio_queue_last_dequeue_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Last recorded dequeue time for a low priority queue item",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "The number of worker threads currently working on some job or spinning while\nwaiting for new work (i.e., not sleeping).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "hiddenSeries": false,
+          "id": 131,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_awake_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of awake worker threads",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "The number of worker threads currently started. Worker threads can be started\nand stopped dynamically based on the server load.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 132,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_num_worker_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Current number of worker threads",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Total number of low priority jobs currently being processed.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 134,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_ongoing_low_prio",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of ongoing RestHandlers coming from the low prio queue",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total number of currently queued jobs in all queues.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 136,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_scheduler_queue_length",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Server's internal queue length",
+          "type": "graph"
+        }
+      ],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 137,
+      "panels": [],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, for application developers",
+  "uid": "QKCUF6uMk",
+  "version": 1
+}

--- a/ArangoDB_3.8/ArangoDB_3.8_for_database_administrators-1619089019860.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_for_database_administrators-1619089019860.json
@@ -1,0 +1,4616 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 4,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_heartbeat_send_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time required to send a heartbeat",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_sum[60s]) / rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 7,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 8,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of AQL queries finished",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of AQL queries executing",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory limit for all AQL queries combined",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 11,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 17,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 18,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 23,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 21,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 22,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 25,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 27,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 26,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 29,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 30,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 33,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 32,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 35,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 36,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 39,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 38,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 41,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 42,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 47,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 49,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 45,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 46,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 51,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 48,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 53,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 50,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 55,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 57,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 54,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 59,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 56,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 61,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 58,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 63,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 60,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 62,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 67,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 64,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 66,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 70,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of intermediate commits performed in transactions.\nAn intermediate commit happens if a logical transaction needs to be\nsplit into multiple physical transaction because of the volume of data\nhandled in the transaction. The thresholds for when to perform an\nintermediate commit can be controlled by startup options \n`--rocksdb.intermediate-commit-count` (number of write operations after\nwhich an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n(cumulated size of write operations after which an intermediate commit is triggered).\nThe values can also be overridden for individual transactions.\nThis metric was named `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_intermediate_commits_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of intermediate commits performed in transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations by synchronous replication.\nThis metric is only present if the option\n`--server.export-read-write-metrics` is set to `true`.\nTotal number of document write operations (insert, update, replace, remove)\nexecuted by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "When using a DC-2-DC configuration of ArangoDB this metric is active on both data-centers.\nIt indicates that the follower data-center peridocally matches the available databases and collections\nin order to mirror them. If no DC-2-DC is set up this value is expected to be 0.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 103,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_cluster_inventory_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "(DC-2-DC only) Number of times the database and collection overviews have been requested",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 212
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of requests required to transport data to this server,\nas a replica for a shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 212
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of bytes replicated in initial asynchronous phase",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 99,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations by synchronous\nreplication on followers. Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 100,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The accumulated time the follower waited for the leader to send\nthe data is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 107,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication requests in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of refusal answers from a follower during synchronous replication.\nA refusal answer will only be sent by a follower if the follower is under\nthe impression that the replication request was not sent by the current\nshard leader. This can happen if replication requests to the follower are \ndelayed or the follower is slow to process incoming requests and there was \na leader change for the shard.\nIf such a refusal answer is received by the shard leader, it will drop the\nfollower from the list of followers.\nThis metrics was named `arangodb_refused_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_refused_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of refusal answers from a follower during synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. Whenever there is a communication issue between the follower and\nthe leader of the shard it will be counted here for the follower. This communication\nissues cover failed connections or http errors, but they also cover invalid or\nunexpected data formats revieved on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 109,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_failed_connects_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of failed connection attempts and response errors during initial asynchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Measures the time required to clone the existing leader copy of the data onto a new replica shard.\nWill only be measured on the follower server. This time is expected to increase whenever new followers\nare created, e.g. increasing replication factor, shard redistribution.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 104,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for requesting actual\ndocuments for the initial replication, in milliseconds. This is part\nof the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the final step of actually\ngetting the needed documents.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 111,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_docs_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to request replication docs data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 106,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for fetching key\nlists for a chunk, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the second step of getting\nlists of key/revision pairs for each chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 113,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_keys_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of data transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 108,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests used in initial asynchronous replication phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of bytes received\nfor initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates number of bytes received for all three steps.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 115,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated amount of bytes received in initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for replication key\nchunks determination requests, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the initial step of getting\nthe checksums for the key chunks.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 110,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_chunks_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication key chunks determination requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents removed on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents removed in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 117,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_removed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents removed by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Accumulated time needed to apply replication initial sync insertions.\nThis counter exhibits the accumulated wait time for actually inserting\ndocuments for the initial synchronization, in milliseconds. This is\npart of the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the actual insertion of\nreplicated documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 112,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_insert_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync insertions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of times documents have been\nfetched on the follower from the leader during initial synchronization\nof shards. This is part of the older (pre 3.8) initial replication\nprotocol, which might still be used in 3.8 for collections which have\nbeen created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of times documents have been\nfetched from the leader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 119,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync docs requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for removing local\ndocuments during initial synchronization of a shard on the follower,\nin milliseconds. This is part of the older (pre 3.8) initial\nreplication protocol, which might still be used in 3.8 for collections\nwhich have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the intermediate step of\nremoving unneeded documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "id": 114,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_remove_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync removals",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of all synchronous replication operation requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 61
+          },
+          "id": 121,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_number_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents inserted on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents inserted in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 69
+          },
+          "id": 116,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_inserted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents inserted by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated time needed to locally process the continuous\nreplication log on a follower received from a replication\nleader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 69
+          },
+          "id": 123,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication tailing data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents fetched on the\nfollower from the leader during initial synchronization of shards.\nThis is part of the older (pre 3.8) initial replication protocol,\nwhich might still be used in 3.8 for collections which have been\ncreated by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents fetched from the\nleader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 77
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requested_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents requested by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of replication tailing document inserts/replaces processed on a follower.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 77
+          },
+          "id": 125,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of replication tailing document inserts/replaces processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of keys requests for\ninitial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric counts the number of times the follower fetches a list of\nkeys for some chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 85
+          },
+          "id": 120,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_keys_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing markers processed on a follower\ndbserver. Markers are specific operations which are part of the\nwrite-ahead log (WAL). Example actions which are being used in\nmarkers: Create or drop a database. Create, drop, rename, change\nor truncate a collection. Create or drop an index. Create, drop,\nchange a view. Start, commit or abort a transaction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 85
+          },
+          "id": 127,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_markers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing markers processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total time needed for all synchronous replication requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 93
+          },
+          "id": 122,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed for all synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Aggregated wait time for replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 93
+          },
+          "id": 129,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregated wait time for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of bytes received from a leader for replication tailing requests. The higher the amount of bytes is, the more data is being processed afterwards on the follower dbserver.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 101
+          },
+          "id": 124,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of bytes received for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 101
+          },
+          "id": 131,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing failures due to missing tick on leader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 109
+          },
+          "id": 126,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_follow_tick_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing failures due to missing tick on leader",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 109
+          },
+          "id": 133,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The amount of document removal based marker operations on a\nfollower dbserver.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 117
+          },
+          "id": 128,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_removals_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing document removals processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of times a mismatching shard checksum was detected when\nsyncing shards. This is a very special metric which is rarely used.\nWhen followers of shards get in sync with their leaders, just when\neverything is completed a final checksum is taken as an additional\nprecaution. If this checksum differs between leader an follower, the\nresync process starts from scratch.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 117
+          },
+          "id": 135,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_sync_wrong_checksum_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a mismatching shard checksum was detected when syncing shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of network replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 125
+          },
+          "id": 130,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 125
+          },
+          "id": 145,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 133
+          },
+          "id": 132,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 141
+          },
+          "id": 134,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 136,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stalled (slowed) write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 6
+          },
+          "id": 137,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stalls_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stalled (slowed) write state",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the number of times RocksDB was observed by\nArangoDB to have entered a stopped write state.\n\nIf the RocksDB background threads which do cleanup and compaction\ncannot keep up with the writing, then RocksDB first throttles its\nwrite rate (\"write stall\") and later stops the writing entirely\n(\"write stop\"). Both are suboptimal, since the write rate is too high,\nbut write stops are considerably worse, since they can lead to service\nunavailability.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 6
+          },
+          "id": 138,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_rocksdb_write_stops_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times RocksDB has entered a stopped write state",
+          "type": "graph"
+        }
+      ],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 139,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 140,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_connection_pool_lease_time_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 141,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time to lease a connection from the connection pool (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 142,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_sum[60s]) / rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time to lease a connection from the connection pool (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 147,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of requests forwarded to another coordinator",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 143,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 144,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agencycomm_request_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Number of outgoing internal requests in flight. This metric is increased\nwhenever any cluster-internal request is about to be sent via the underlying \nconnection pool, and is decreased whenever a response for such a request is\nreceived or the request runs into a timeout.\nThis metric provides an estimate of the fan-out of operations. For example,\na user operation on a collection with a single shard will normally lead to\na single internal request (plus replication), whereas an operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 149,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_network_requests_in_flight",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of outgoing internal requests in flight",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 146,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_sum[60s]) / rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 154,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter failures",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of internal requests that have timed out. This metric is increased\nwhenever any cluster-internal request executed in the underlying connection\npool runs into a timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 148,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_request_timeouts_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of internal requests that have timed out",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 156,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context exit events",
+          "type": "graph"
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 150,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 151,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever created",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 152,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated total time for creating V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 153,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever destroyed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 155,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter events",
+          "type": "graph"
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 157,
+      "panels": [],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 158,
+      "panels": [],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 159,
+      "panels": [],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, for database administrators",
+  "uid": "K-HuFeXMz",
+  "version": 1
+}

--- a/ArangoDB_3.8/ArangoDB_3.8_for_database_users-1619089247259.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_for_database_users-1619089247259.json
@@ -1,0 +1,4018 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of AQL queries finished",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Current number of AQL queries executing",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total memory limit for all AQL queries combined",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 11,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 17,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 18,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total amount of time it took to acquire collection/shard locks for\nwrite operations, summed up for all collections/shards. Will not be increased \nfor any read operations.\nThe value is measured in microseconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_acquisition_micros_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total amount of collection lock acquisition time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of transactions using sequential locking of collections to avoid deadlocking.\nBy default, a coordinator will try to lock all shards of a collection in parallel.\nThis approach is normally fast but can cause deadlocks with other transactions that\nlock the same shards in a different order. In case such a deadlock is detected, the\ncoordinator will abort the lock round and start a new one that locks all shards in\nsequential order. This will avoid deadlocks, but has a higher setup overhead.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_sequential_mode_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions using sequential locking of collections to avoid deadlocking",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection exclusive locks.\nThis counter will be increased whenever an exclusive collection lock\ncannot be acquired within the configured lock timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 21,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_exclusive_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection exclusive locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of timeouts when trying to acquire collection write locks.\nThis counter will be increased whenever a collection write lock\ncannot be acquired within the configured lock timeout. \nThis can only happen if writes on a collection are locked out by\nother operations on the collection that use an exclusive lock. Writes\nare not locked out by other, non-exclusively locked writes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 22,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_lock_timeouts_write_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of timeouts when trying to acquire collection write locks",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 23,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 25,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 26,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 27,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 29,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 30,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 32,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 33,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 35,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 36,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 38,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 39,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 41,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations (insert, update, replace, remove) on\nleaders, excluding writes by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 42,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 99
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 99
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 107
+          },
+          "id": 45,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 107
+          },
+          "id": 46,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 47,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 48,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 49,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 50,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 51,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 53,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 54,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 55,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 56,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 57,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 58,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 59,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 60,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 61,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 62,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 63,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 64,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 66,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 67,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 70,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 99,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 100,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 103,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 104,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 106,
+      "panels": [],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 107,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 108,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_connection_pool_lease_time_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 109,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time to lease a connection from the connection pool (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 110,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_sum[60s]) / rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time to lease a connection from the connection pool (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 115,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Accumulated total time for creating V8 contexts",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 111,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 112,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of requests forwarded to another coordinator",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 117,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context enter failures",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 113,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 114,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 contexts ever created",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 119,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context exit events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 116,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 contexts ever destroyed",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter events",
+          "type": "graph"
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 120,
+      "panels": [],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 121,
+      "panels": [],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 122,
+      "panels": [],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, for database users",
+  "uid": "9YVm56XGz",
+  "version": 1
+}

--- a/ArangoDB_3.8/ArangoDB_3.8_for_system_administrators-1619089200357.json
+++ b/ArangoDB_3.8/ArangoDB_3.8_for_system_administrators-1619089200357.json
@@ -1,0 +1,4565 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.4"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of drop-follower events. This metric is increased on leaders\nwhenever a write operation cannot be replicated to a follower during\nsynchronous replication, and it would be unsafe in terms of data consistency \nto keep that follower.\nThis metric was named `arangodb_dropped_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_dropped_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of drop-follower events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of failed heartbeat transmissions.\nServers in a cluster periodically send their heartbeats to\nthe agency to report their own liveliness. This counter gets\nincreased whenever sending such a heartbeat fails. In the single\nserver, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of failed heartbeat transmissions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 4,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_heartbeat_send_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time required to send a heartbeat",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Histogram of times required to send heartbeats. For every heartbeat\nsent the time is measured and an event is put into the histogram.\nIn the single server, this counter is only used in active failover mode.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_heartbeat_send_time_msec_sum[60s]) / rate(arangodb_heartbeat_send_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time required to send a heartbeat (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 7,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of AQL queries finished.\nThis metric was named `arangodb_aql_all_query` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 8,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_all_query_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of AQL queries finished",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Current number of AQL queries executing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 9,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_current_query",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Current number of AQL queries executing",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory limit for all AQL queries combined, in bytes.\nIf this value is reported as `0`, it means there is no total memory\nlimit in place for AQL queries. The value can be adjusted by the setting\nthe `--query.global-memory-limit` startup option.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 10,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_limit",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory limit for all AQL queries combined",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total memory usage of all AQL queries currently executing.\nThe granularity of this metric is steps of 32768 bytes. The current\nmemory usage of all AQL queries will be compared against the configured\nlimit in the `--query.global-memory-limit` startup option. \nIf the startup option has a value of `0`, then no global memory limit\nwill be enforced. If the startup option has a non-zero value, queries\nwill be aborted once the total query memory usage goes above the configured\nlimit.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 11,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_aql_global_memory_usage",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total memory usage of all AQL queries executing; granularity: 32768 bytes steps",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times the global query memory limit threshold was reached.\nThis can happen if all running AQL queries in total try to use more memory than\nconfigured via the `--query.global-memory-limit` startup option.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 12,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_global_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times the global query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of times a local query memory limit threshold was reached, i.e.\na single query tried to allocate more memory than configured in the query's\n`memoryLimit` attribute or the value configured via the startup option\n`--query.memory-limit`.\nEvery time this counter will increase, an AQL query will have aborted with a \n\"resource limit exceeded\" error.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 13,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_local_query_memory_limit_reached[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a local query memory limit threshold was reached",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 14,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 15,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for all AQL queries, in seconds.\nThe histogram includes all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 16,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_query_time_sum[60s]) / rate(arangodb_aql_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for all AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 17,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_aql_slow_query_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 18,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Execution time histogram for slow AQL queries, in seconds.\nQueries are considered \"slow\" if their execution time is above the\nthreshold configured in the startup options `--query.slow-threshold`\nor `--query.slow-streaming-threshold`, resp.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 19,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_slow_query_time_sum[60s]) / rate(arangodb_aql_slow_query_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution time histogram for slow AQL queries (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total execution time of all AQL queries, in milliseconds,\nincluding all slow queries.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 20,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_aql_total_query_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total execution time of all AQL queries",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 23,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (count of events per second)",
+          "type": "graph"
+        }
+      ],
+      "title": "AQL",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 21,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 22,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_collection_truncate_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations on leaders (excl. synchronous\nreplication). Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 25,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations (excl. synchronous replication)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in collection truncate operations, including both\nuser-initiated truncate operations and truncate operations\nexecuted by the synchronous replication on followers.\nNote that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 24,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncate_time_sum[60s]) / rate(arangodb_collection_truncate_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in collection truncate operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 27,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 26,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_insert_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 29,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_read_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document insert operations, including both\nuser-initiated insert operations and insert operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 28,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_insert_time_sum[60s]) / rate(arangodb_document_insert_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document insert operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 31,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_sum[60s]) / rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document read-by-primary-key operations. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 30,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_read_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document read-by-primary-key operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 33,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 32,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_remove_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 35,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_replace_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 34,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_remove_time_sum[60s]) / rate(arangodb_document_remove_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document remove operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 37,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_sum[60s]) / rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document replace operations, including both\nuser-initiated replace operations and replace operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 36,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_replace_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document replace operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 59
+          },
+          "id": 39,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 67
+          },
+          "id": 38,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_document_update_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions aborted. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_aborted` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 67
+          },
+          "id": 41,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_aborted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions aborted",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total time spent in document update operations, including both\nuser-initiated update operations and update operations executed by\nthe synchronous replication on followers. This metric\nis only present if the option `--server.export-read-write-metrics` is set\nto `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 40,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_update_time_sum[60s]) / rate(arangodb_document_update_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time spent in document update operations (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of expired transactions, i.e. transactions that have\nbeen begun but that were automatically garbage-collected due to \ninactivity within the transactions' time-to-live (TTL) period.\nIn the cluster, this metric will be collected separately for transactions \non coordinators and the transaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_expired` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 43,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_expired_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of expired transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions committed. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_committed` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 42,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_committed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions committed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 47,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of transactions started/begun. In the cluster, this metric will \nbe collected separately for transactions on coordinators and the\ntransaction counterparts on leaders and followers.\nThis metric was named `arangodb_transactions_started` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 44,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_transactions_started_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of transactions started",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 49,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_sent_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request",
+          "type": "heatmap"
+        }
+      ],
+      "title": "Transactions",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 45,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 46,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_bytes_received_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 51,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the received request sizes in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 48,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_received_sum[60s]) / rate(arangodb_client_connection_statistics_bytes_received_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes received for a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 53,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_io_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the sent response sizes in bytes\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 50,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_bytes_sent_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes sent for a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 55,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_sum[60s]) / rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of client connections that are currently open.\nNote: this metric considers only HTTP and HTTP/2 connections, but not VST\nconnections.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 52,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_client_connection_statistics_client_connections",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "The number of client connections that are currently open",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 57,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of I/O times needed to answer a request. This includes the time\nrequired to read the incoming request as well as the time required to send\nthe response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 54,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_io_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "I/O time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 59,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_request_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 56,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_queue_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 61,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_sum[60s]) / rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time requests are spending on a queue waiting to be\nprocessed. The overwhelming majority of these times should be clearly\nsub-second.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 58,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_queue_time_sum[60s]) / rate(arangodb_client_connection_statistics_queue_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queueing time needed for requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 63,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the time required to actually process a request. This does not\ninclude the time required to read the incoming request, the time the request\nis sitting on the queue, or the time required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "id": 60,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_request_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time needed to answer a request (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of **asynchronous** HTTP (or VST)\nrequests which have hit this particular instance of `arangod`. Asynchronous\nrefers to the fact that the response is not sent with the HTTP response,\nbut is rather queried separately using the `/_api/jobs` API.\nSee [this Section](async-results-management.html) for details.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "id": 65,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_async_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of asynchronously executed HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "id": 62,
+          "legend": {
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_client_connection_statistics_total_time_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request",
+          "type": "heatmap"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **GET** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "id": 67,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_get_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP GET requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Histogram of the total times required to process a request. This includes\nthe time required to read the incoming request, the time the request is\nsitting in the queue, the time to actually process the request, and the\ntime required to send the response.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 64,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_client_connection_statistics_total_time_sum[60s]) / rate(arangodb_client_connection_statistics_total_time_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed to answer a request (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **OPTIONS** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 69,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_options_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP OPTIONS requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **DELETE** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 84
+          },
+          "id": 66,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_delete_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP DELETE requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **POST** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 84
+          },
+          "id": 71,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_post_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP POST requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **HEAD** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 92
+          },
+          "id": 68,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_head_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP HEAD requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **other**\nor **ILLEGAL** requests which have hit this particular instance of\n`arangod`. These are all requests, which are not one of the following:\n`DELETE`, `GET`, `HEAD`, `POST`, `PUT`, `OPTIONS`, `PATCH`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 92
+          },
+          "id": 73,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_other_http_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of other HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PATCH** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 100
+          },
+          "id": 70,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_patch_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PATCH requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests which\nhave hit this particular instance of `arangod`. Note that this counter\nis ever growing during the lifetime of the `arangod` process. However,\nwhen the process is restarted, it starts from scratch. In the Grafana\ndashboards, it is usually visualized as a rate per second, averaged\nwith a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 100
+          },
+          "id": 75,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_total_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) **PUT** \nrequests which have hit this particular instance of `arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 108
+          },
+          "id": 72,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_http_put_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of HTTP PUT requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of intermediate commits performed in transactions.\nAn intermediate commit happens if a logical transaction needs to be\nsplit into multiple physical transaction because of the volume of data\nhandled in the transaction. The thresholds for when to perform an\nintermediate commit can be controlled by startup options \n`--rocksdb.intermediate-commit-count` (number of write operations after\nwhich an intermediate commit is triggered) and `--rocksdb.intermediate-commit-size`\n(cumulated size of write operations after which an intermediate commit is triggered).\nThe values can also be overridden for individual transactions.\nThis metric was named `arangodb_intermediate_commits` in previous\nversions of ArangoDb.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 108
+          },
+          "id": 77,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_intermediate_commits_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of intermediate commits performed in transactions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST)\nrequests that have been authenticated with the JWT superuser token,\nwhich have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 116
+          },
+          "id": 74,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_superuser_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by superuser/JWT",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of minor faults the process has made which have not required\nloading a memory page from disk. This figure is not reported on Windows.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 116
+          },
+          "id": 79,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_minor_page_faults_total",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of minor page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of HTTP (or VST) requests\nthat have been authenticated for some user (as opposed to with the\nJWT superuser token), which have hit this particular instance of\n`arangod`.\n\nNote that this counter is ever growing during the lifetime of the\n`arangod` process. However, when the process is restarted, it starts\nfrom scratch. In the Grafana dashboards, it is usually visualized as a\nrate per second, averaged with a sliding window of a minute.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "id": 76,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_http_request_statistics_user_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of HTTP requests executed by user clients",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total size of the number of pages the process has in real memory.\nThis is just the pages which count toward text, data, or stack space.\nThis does not include pages which have not been demand-loaded in, or\nwhich are swapped out. The resident set size is reported in bytes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "id": 81,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total number of page faults.\nOn other system, this figure contains the number of major faults the\nprocess has made which have required loading a memory page from disk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "id": 78,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_process_statistics_major_page_faults_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of major page faults",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in kernel mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "id": 83,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_system_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process system time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of threads in the arangod process.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 140
+          },
+          "id": 80,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_number_of_threads",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of threads",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "On Windows, this figure contains the total amount of memory that the\nmemory manager has committed for the arangod process. On other systems,\nthis figure contains the size of the virtual memory the process is\nusing.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 140
+          },
+          "id": 85,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_virtual_memory_size",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Virtual memory size",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The relative size of the number of pages the process has in real\nmemory compared to system memory. This is just the pages which count\ntoward text, data, or stack space. This does not include pages which\nhave not been demand-loaded in, or which are swapped out. The value is a\nratio between 0.00 and 1.00.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 148
+          },
+          "id": 82,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_resident_set_size_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Resident set size as fraction of system memory",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been idle, as \na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 148
+          },
+          "id": 87,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_idle_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been idle",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Amount of time that this process has been scheduled in user mode,\nmeasured in seconds.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 156
+          },
+          "id": 84,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_process_statistics_user_time",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process user time",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Physical memory of the system in bytes, as reported by the operating system \nunless the environment variable `ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY` \nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 156
+          },
+          "id": 89,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_physical_memory",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Physical memory in bytes",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of CPU cores visible to the arangod process, unless the\nenvironment variable `ARANGODB_OVERRIDE_DETECTED_NUMBER_OF_CORES`\nis set. In that case, the environment variable's value will be reported.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "id": 86,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_cpu_cores",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of CPU cores visible to the arangod process",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in kernel mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "id": 91,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_system_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in kernel mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have been waiting for I/O, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "id": 88,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_iowait_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have been waiting for I/O",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently alive. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "id": 93,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_alive",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently alive",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of seconds elapsed since server start, including fractional\nseconds.\nThis metric was named `arangodb_server_statistics_server_uptime`\nin previous versions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "id": 90,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_server_statistics_server_uptime_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of seconds elapsed since server start",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently dirty.\nA V8 context is dirty, if it has executed JavaScript for some time and\nis due for a garbage collection.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "id": 95,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_dirty",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently dirty",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of time that the system CPUs have spent in user mode, as\na value between 0 and 100, and as reported by the operating system.\nThis metric is only reported on some operating systems.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 188
+          },
+          "id": 92,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_server_statistics_user_percent",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Percentage of time that the system CPUs have spent in user mode",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the maximum number of concurrent V8 contexts. This is limited\nby a server option, since V8 contexts can use a lot of RAM. V8 contexts\nare created and destroyed as needed up to the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 188
+          },
+          "id": 97,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_max",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Maximum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of V8 contexts currently busy, that means, they are currently\nworking on some JavaScript task. Normally, only coordinators and\nsingle servers should have V8 contexts, for dbservers and agents the\nvalue is always zero.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 196
+          },
+          "id": 94,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_busy",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently busy",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of document write operations by synchronous replication.\nThis metric is only present if the option\n`--server.export-read-write-metrics` is set to `true`.\nTotal number of document write operations (insert, update, replace, remove)\nexecuted by the synchronous replication on followers.\nThis metric is only present if the option `--server.export-read-write-metrics` \nis set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 196
+          },
+          "id": 101,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_document_writes_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of document write operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This gauge reflects the number of V8 contexts that are currently free.\nIf this number drops to 0 there might be a shortage of V8 contexts.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 204
+          },
+          "id": 96,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_free",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of V8 contexts currently free",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "When using a DC-2-DC configuration of ArangoDB this metric is active on both data-centers.\nIt indicates that the follower data-center peridocally matches the available databases and collections\nin order to mirror them. If no DC-2-DC is set up this value is expected to be 0.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 204
+          },
+          "id": 103,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_cluster_inventory_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "(DC-2-DC only) Number of times the database and collection overviews have been requested",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This is the minimum number of concurrent V8 contexts. This is limited\nby a server option. V8 contexts are created and destroyed as needed\nbut there are never fewer than the limit shown in this metric.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 212
+          },
+          "id": 98,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_v8_context_min",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Minimum number of concurrent V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of requests required to transport data to this server,\nas a replica for a shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 212
+          },
+          "id": 105,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of bytes replicated in initial asynchronous phase",
+          "type": "graph"
+        }
+      ],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 99,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Total number of collection truncate operations by synchronous\nreplication on followers. Note that this metric is only present when the command\nline option `--server.export-read-write-metrics` is set to `true`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 100,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_collection_truncates_replication_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of collection truncate operations by synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The accumulated time the follower waited for the leader to send\nthe data is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 107,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication requests in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of refusal answers from a follower during synchronous replication.\nA refusal answer will only be sent by a follower if the follower is under\nthe impression that the replication request was not sent by the current\nshard leader. This can happen if replication requests to the follower are \ndelayed or the follower is slow to process incoming requests and there was \na leader change for the shard.\nIf such a refusal answer is received by the shard leader, it will drop the\nfollower from the list of followers.\nThis metrics was named `arangodb_refused_followers_count` in previous\nversions of ArangoDB.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 102,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_refused_followers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of refusal answers from a follower during synchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. Whenever there is a communication issue between the follower and\nthe leader of the shard it will be counted here for the follower. This communication\nissues cover failed connections or http errors, but they also cover invalid or\nunexpected data formats revieved on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 109,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_failed_connects_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of failed connection attempts and response errors during initial asynchronous replication",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Measures the time required to clone the existing leader copy of the data onto a new replica shard.\nWill only be measured on the follower server. This time is expected to increase whenever new followers\nare created, e.g. increasing replication factor, shard redistribution.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 104,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply asynchronously replicated data on initial synchronization of shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for requesting actual\ndocuments for the initial replication, in milliseconds. This is part\nof the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the final step of actually\ngetting the needed documents.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 111,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_docs_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to request replication docs data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of documents transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 106,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of documents replicated in initial asynchronous phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for fetching key\nlists for a chunk, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the second step of getting\nlists of key/revision pairs for each chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 113,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_keys_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "During initial replication the existing data from the leader is copied asynchronously\nover to new shards. The amount of data transported to this server, as a replica for\na shard, is counted here.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 108,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_dump_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests used in initial asynchronous replication phase",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of bytes received\nfor initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates number of bytes received for all three steps.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 115,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated amount of bytes received in initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for replication key\nchunks determination requests, in milliseconds. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the initial step of getting\nthe checksums for the key chunks.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 110,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_chunks_requests_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated wait time for replication key chunks determination requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents removed on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents removed in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 117,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_removed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents removed by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Accumulated time needed to apply replication initial sync insertions.\nThis counter exhibits the accumulated wait time for actually inserting\ndocuments for the initial synchronization, in milliseconds. This is\npart of the older (pre 3.8) initial replication protocol, which might\nstill be used in 3.8 for collections which have been created by older\nversions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the actual insertion of\nreplicated documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "id": 112,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_insert_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync insertions",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of times documents have been\nfetched on the follower from the leader during initial synchronization\nof shards. This is part of the older (pre 3.8) initial replication\nprotocol, which might still be used in 3.8 for collections which have\nbeen created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of times documents have been\nfetched from the leader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "id": 119,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync docs requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated wait time for removing local\ndocuments during initial synchronization of a shard on the follower,\nin milliseconds. This is part of the older (pre 3.8) initial\nreplication protocol, which might still be used in 3.8 for collections\nwhich have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the time used for the intermediate step of\nremoving unneeded documents on the follower.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "id": 114,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_remove_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication initial sync removals",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of all synchronous replication operation requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 61
+          },
+          "id": 121,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_number_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents inserted on the\nfollower during initial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be\nused in 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents inserted in the\nthird step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 69
+          },
+          "id": 116,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_inserted_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents inserted by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated time needed to locally process the continuous\nreplication log on a follower received from a replication\nleader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 69
+          },
+          "id": 123,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_apply_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated time needed to apply replication tailing data",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the total number of documents fetched on the\nfollower from the leader during initial synchronization of shards.\nThis is part of the older (pre 3.8) initial replication protocol,\nwhich might still be used in 3.8 for collections which have been\ncreated by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric accumulates the total number of documents fetched from the\nleader in the third step.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 77
+          },
+          "id": 118,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_docs_requested_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of documents requested by replication initial sync",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of replication tailing document inserts/replaces processed on a follower.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 77
+          },
+          "id": 125,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_documents_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of replication tailing document inserts/replaces processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter exhibits the accumulated number of keys requests for\ninitial synchronization of shards. This is part of the\nolder (pre 3.8) initial replication protocol, which might still be used\nin 3.8 for collections which have been created by older versions.\n\nIn this older protocol, the follower first fetches an overview over\na shard from the leader. This does a full collection scan and\ndivides the primary keys in the collection into equal sized chunks.\nThen, a checksum for each chunk is returned. The same is then done\non the follower and the checksums are compared, chunk by chunk. For\neach chunk, for which the checksums do not match, the list of keys and\nrevisions is fetched from the leader. This then enables the follower\nto fetch the actually needed documents and remove superfluous ones\nlocally.\n\nThis metric counts the number of times the follower fetches a list of\nkeys for some chunk.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 85
+          },
+          "id": 120,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_initial_sync_keys_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication initial sync keys requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing markers processed on a follower\ndbserver. Markers are specific operations which are part of the\nwrite-ahead log (WAL). Example actions which are being used in\nmarkers: Create or drop a database. Create, drop, rename, change\nor truncate a collection. Create or drop an index. Create, drop,\nchange a view. Start, commit or abort a transaction.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 85
+          },
+          "id": 127,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_markers_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing markers processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total time needed for all synchronous replication requests\nbetween dbservers being done.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 93
+          },
+          "id": 122,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_synchronous_requests_total_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total time needed for all synchronous replication requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Aggregated wait time for replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 93
+          },
+          "id": 129,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_request_time_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregated wait time for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The accumulated number of bytes received from a leader for replication tailing requests. The higher the amount of bytes is, the more data is being processed afterwards on the follower dbserver.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 101
+          },
+          "id": 124,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_bytes_received_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated number of bytes received for replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards on this machine. Every shard has a leader and\npotentially multiple followers.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 101
+          },
+          "id": 131,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_leader_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The number of replication tailing failures due to missing tick on leader.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 109
+          },
+          "id": 126,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_follow_tick_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing failures due to missing tick on leader",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards on this machine. Every shard has a leader and\npotentially multiple followers. This metric counts both leader and\nfollower shards.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 109
+          },
+          "id": 133,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_number",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards on this machine",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The amount of document removal based marker operations on a\nfollower dbserver.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 117
+          },
+          "id": 128,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_removals_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing document removals processed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of times a mismatching shard checksum was detected when\nsyncing shards. This is a very special metric which is rarely used.\nWhen followers of shards get in sync with their leaders, just when\neverything is completed a final checksum is taken as an additional\nprecaution. If this checksum differs between leader an follower, the\nresync process starts from scratch.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 117
+          },
+          "id": 135,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_sync_wrong_checksum_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of times a mismatching shard checksum was detected when syncing shards",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "The total amount of network replication tailing requests.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 125
+          },
+          "id": 130,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_replication_tailing_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of replication tailing requests",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 125
+          },
+          "id": 143,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (count of events per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of shards not replicated at all. This is counted for all shards\nfor which this server is currently the leader. The number is increased\nby one for every shards for which no follower is in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 133
+          },
+          "id": 132,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_not_replicated",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of shards not replicated at all",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of requests forwarded to another coordinator.\nRequest forwarding can happen in load-balanced setups,\nwhen one coordinator receives and forwards requests \nthat can only be handled by a different coordinator.\nThis includes requests for streaming transactions,\nAQL, query cursors, Pregel jobs and some others.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 133
+          },
+          "id": 145,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_forwarded_requests_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of requests forwarded to another coordinator",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of leader shards not fully replicated. This is counted for all\nshards for which this server is currently the leader. The number is\nincreased by one for every shards for which not all followers are in sync.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 141
+          },
+          "id": 134,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "arangodb_shards_out_of_sync",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of leader shards not fully replicated",
+          "type": "graph"
+        }
+      ],
+      "title": "Replication",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 136,
+      "panels": [],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 137,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 138,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_connection_pool_lease_time_hist_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Time to lease a connection from the connection pool",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 139,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time to lease a connection from the connection pool (count of events per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Time to lease a connection from the connection pool. There are two pools,\none for the agency communication with label `AgencyComm` and one for\nthe other cluster internal communication with label `ClusterComm`.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 140,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_connection_pool_lease_time_hist_sum[60s]) / rate(arangodb_connection_pool_lease_time_hist_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time to lease a connection from the connection pool (average per second)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Number of outgoing internal requests in flight. This metric is increased\nwhenever any cluster-internal request is about to be sent via the underlying \nconnection pool, and is decreased whenever a response for such a request is\nreceived or the request runs into a timeout.\nThis metric provides an estimate of the fan-out of operations. For example,\na user operation on a collection with a single shard will normally lead to\na single internal request (plus replication), whereas an operation on a\ncollection with 10 shards may lead to a fan-out of 10 (plus replication).\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 147,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "arangodb_network_requests_in_flight",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of outgoing internal requests in flight",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Connectivity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 141,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 142,
+          "legend": {
+            "show": false
+          },
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(arangodb_agencycomm_request_time_msec_bucket[60s])) by (le))",
+              "format": "heatmap",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "Total number of V8 context enter failures. A context receives a context\nenter event every time it begins to execute some JavaScript. If no\ncontext is available at such a time the system waits for 60s for a\ncontext to become free. If this does not happen within the 60s, the\ncontext enter event fails, a warning is logged and this counter is\nincreased by one.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 152,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_enter_failures_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total number of V8 context enter failures",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "This histogram shows how long requests to the agency took.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 144,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_agencycomm_request_time_msec_sum[60s]) / rate(arangodb_agencycomm_request_time_msec_count[60s])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request time for Agency requests (average per second)",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 context exit events.\nA context receives a context exit event every time it finishes to\nexecute some JavaScript.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 154,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_exited_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context exit events",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Number of internal requests that have timed out. This metric is increased\nwhenever any cluster-internal request executed in the underlying connection\npool runs into a timeout.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 146,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_network_request_timeouts_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Number of internal requests that have timed out",
+          "type": "graph"
+        }
+      ],
+      "title": "Network",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 148,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever created. It is\nOK if this number keeps growing since the V8 contexts are created and\ndestroyed as needed. In rare cases a high fluctuation can indicate\nsome unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 149,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_created_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever created",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the accumulated total time for creating V8\ncontexts, in milliseconds. It is OK if this number keeps growing since\nthe V8 contexts are created and destroyed as needed. In rare cases a\nhigh fluctuation can indicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 150,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_creation_time_msec_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Accumulated total time for creating V8 contexts",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "This counter reflects the total number of V8 contexts ever destroyed.\nIt is OK if this number keeps growing since the V8 contexts are\ncreated and destroyed as needed. In rare cases a high fluctuation can\nindicate some unfortunate usage pattern.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 151,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_destroyed_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 contexts ever destroyed",
+          "type": "graph"
+        },
+        {
+          "datasource": null,
+          "description": "Total number of V8 context enter events. A context receives a context\nenter event every time it begins to execute some JavaScript. This number\nis a rough estimate as to how much JavaScript the server executes.\n",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 153,
+          "pluginVersion": "7.5.4",
+          "targets": [
+            {
+              "expr": "rate(arangodb_v8_context_entered_total[1m])",
+              "legendFormat": "{{instance}}:{{shortname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Total number of V8 context enter events",
+          "type": "graph"
+        }
+      ],
+      "title": "V8",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 155,
+      "panels": [],
+      "title": "Agency",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 156,
+      "panels": [],
+      "title": "Scheduler",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 157,
+      "panels": [],
+      "title": "Maintenance",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ArangoDB 3.8, for system administrators",
+  "uid": "AHQgceXGk",
+  "version": 1
+}


### PR DESCRIPTION
This adds a new directory with different dashboards for different
personas. They have been automatically generated from the new metrics
documentation and meta data, have been imported into Grafana and then
re-exported "for external use".

We might need slightly different ones for use in k8s, we need to check.
